### PR TITLE
SSCS-2669: Implement Crossbrowser testing with Saucelabs (reporting fix)

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -17,9 +17,5 @@ withNightlyPipeline("nodejs", product, component) {
 
     enableCrossBrowserTest()
 
-    after('crossBrowserTest') {
-        steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
-    }
-
 //    enableSlackNotifications('#sscs')  // can be turned back on once the overnight functionality is working fully
 }

--- a/config/default.json
+++ b/config/default.json
@@ -51,6 +51,7 @@
     "username": "username",
     "key": "privatekey",
     "tunnelId": "reformtunnel",
-    "smartWait": "10000"
+    "smartWait": "10000",
+    "outputDir": "./functional-output/crossbrowser/reports"
   }
 }

--- a/test/e2e/saucelabs.conf.js
+++ b/test/e2e/saucelabs.conf.js
@@ -27,7 +27,7 @@ const getBrowserConfig = browserGroup => {
 
 const setupConfig = {
   tests: './smoke/appeal.test.js',
-  output: process.env.E2E_OUTPUT_DIR || config.get('e2e.outputDir'),
+  output: config.get('saucelabs.outputDir'),
   features: {
     evidenceUpload: {
       enabled: evidenceUploadEnabled
@@ -70,7 +70,7 @@ const setupConfig = {
       mochawesome: {
         stdout: './functional-output/console.log',
         options: {
-          reportDir: process.env.E2E_OUTPUT_DIR || config.get('e2e.outputDir'),
+          reportDir: config.get('saucelabs.outputDir'),
           reportName: 'index',
           inlineAssets: true
         }


### PR DESCRIPTION
## WHAT?
This is a fix for gathering reports in Jenkins from the overnight pipeline.

## WHY?
The wrong `functional-output` folder structure was being used, so when Jenkins tried to find the reports to save them they weren't where it expected. This change now uses the correct location for the crossbrowser output.

## HOW?
A new `saucelabs.outputDir` config value was created and used, and the unnecessary archiving pipeline code was removed.