### PR TITLE
Exclude `/steps` from sonar check

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:crossbrowser": "cross-env NODE_PATH=. NODE_ENV=test codeceptjs run-multiple ${BROWSER_GROUP:-'--all'} -c test/e2e/saucelabs.conf.js --steps --reporter mocha-multi --verbose",
     "test:nsp": "nsp check",
     "test:a11y": "cross-env NODE_PATH=. NODE_ENV=a11y LOG_LEVEL=ERROR mocha test/accessibility/a11y.js --exit --timeout 60000 --reporter mochawesome --reporter-options reportFilename=a11y,inlineAssets=true,reportTitle=submit-your-appeal",
-    "sonar-scan": "sonar-scanner -Dsonar.projectName='SSCS :: Submit Your Appeal frontend' -Dsonar.projectKey='SSCSSYAF' -Dsonar.sources=. -Dsonar.exclusions=steps/compliance/mrn-over-thirteen-months-late/MRNOverThirteenMonthsLate.js,steps/compliance/mrn-over-thirteen-months-late/MRNOverThirteenMonthsLate.js,app.js,app-insights.js,server.js,node_modules/**,test/**,assets/**,dist/**,mochawesome-report/** -Dsonar.javascript.lcov.reportPaths=test/unit/coverage/html/lcov.info",
+    "sonar-scan": "sonar-scanner -Dsonar.projectName='SSCS :: Submit Your Appeal frontend' -Dsonar.projectKey='SSCSSYAF' -Dsonar.sources=. -Dsonar.exclusions=app.js,app-insights.js,server.js,node_modules/**,test/**,assets/**,dist/**,mochawesome-report/** -Dsonar.javascript.lcov.reportPaths=test/unit/coverage/html/lcov.info -Dsonar.cpd.exclusions=steps/**",
     "mock-uploader": "node test/file_acceptor/evidence_uploader.js"
   },
   "pre-commit": [


### PR DESCRIPTION
The use pattern of OPP leads to duplication. While we are aware of this not being a good pattern, consistency is important so we're excluding the `steps` folder until we have a better use pattern with less repetition.