### PR TITLE
MRN page accessibility issues

### DIFF
--- a/paths.js
+++ b/paths.js
@@ -39,7 +39,7 @@ module.exports = {
   appealFormDownload: '/appeal-form-download',
 
   compliance: {
-    haveAMRN: '/have-a-mrn',
+    haveAMRN: '/have-you-got-an-mrn',
     haveContactedDWP: '/have-contacted-dwp',
     dwpIssuingOffice: '/dwp-issuing-office',
     dwpIssuingOfficeESA: '/dwp-issuing-office-esa',

--- a/steps/compliance/have-a-mrn/content.en.json
+++ b/steps/compliance/have-a-mrn/content.en.json
@@ -1,5 +1,5 @@
 {
-  "titleHead": "Have MRN - Appeal a benefit decision - GOV.UK",
+  "titleHead": "Have you got an MRN - Appeal a benefit decision - GOV.UK",
   "title": "Have you got a Mandatory Reconsideration Notice (MRN)?",
   "subtitle": "This is the letter DWP sent you when you asked them to reconsider their decision about the {{benefitType}} benefit.",
   "fields": {


### PR DESCRIPTION
Have you got MRN page improvements for screen readers:
- URI is now /have-you-got-an-mrn
- Browser tab title reads "Have you got an MRN - Appeal a benefit decision - GOV.UK"

Solves https://tools.hmcts.net/jira/browse/SSCS-3429
