### PR TITLE
Optimise docker image build layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,11 @@
-node_modules/
 bin/
+functional-output/
+infrastructure/
+kubernetes/
+mocks/
+node_modules/
+smoke-output/
+test/
 .dockerignore
 .git
 .gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ FROM node:8.9.4-slim
 ENV NODE_PATH .
 ENV NODE_ENV development
 
-RUN mkdir -p /usr/src/sya
 WORKDIR /usr/src/sya
 
-COPY . /usr/src/sya/
-
 RUN yarn config set proxy "$http_proxy" \
- && yarn config set https-proxy "$https_proxy"
+    && yarn config set https-proxy "$https_proxy"
+
+COPY package.json yarn.lock ./
 
 RUN yarn install --production && yarn cache clean
+
+COPY . .
 
 CMD [ "node", "server.js" ]


### PR DESCRIPTION
JIRA ticket: [CNP-1104](https://tools.hmcts.net/jira/browse/CNP-1104)

Hello, this PR adds the following enhancements:
- improve the ordering of the docker image build layer 
- prepare for future ACR cache optimisations.

This is part of a general [pipelines optimisations initiative](https://tools.hmcts.net/confluence/display/CNP/Pipeline+optimisations) and should not impact the current builds.

---

**Nota bene**: for this specific project, if you manage to separate the static build from being executed when the applications starts, it would allow enhanced future performance optimisations. Currently it seems like the webpack bundling is triggered on each application start.