### PR TITLE
Freeze `applicationinsights` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@hmcts/one-per-page": "5.0.1",
     "@hmcts/uk-bank-holidays": "^1.0.1",
     "accessible-autocomplete": "^1.6.1",
-    "applicationinsights": "^1.0.3",
+    "applicationinsights": "1.0.3",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
     "babel-preset-env": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -275,9 +275,10 @@ append-transform@^0.4.0:
   dependencies:
     default-require-extensions "^1.0.0"
 
-applicationinsights@^1.0.3:
+applicationinsights@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.3.tgz#ddbf503612cbbfd7c28e087894dd28cfb06450a1"
+  integrity sha1-3b9QNhLLv9fCjgh4lN0oz7BkUKE=
   dependencies:
     diagnostic-channel "0.2.0"
     diagnostic-channel-publishers "0.2.1"


### PR DESCRIPTION
The latest version of `applicationinsights` (1.1.0)  breaks this test

https://github.com/hmcts/sscs-submit-your-appeal/blob/d04c13d8b91fdbd9809bceee4484c93477b550d8/test/unit/logger.test.js#L43

Presumably, the package has introduced a non backward compatible change.

We're tracking the issue here: https://tools.hmcts.net/jira/browse/SSCS-5143