### PR TITLE
Fix product/component split

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -6,8 +6,8 @@ properties(
 
 @Library("Infrastructure")
 
-def product = "sscs-tribunals"
-def component = "frontend"
+def product = "sscs"
+def component = "tribunals-frontend"
 
 withPipeline("nodejs", product, component) {
     enableDockerBuild()

--- a/logger.js
+++ b/logger.js
@@ -15,11 +15,8 @@ module.exports = class Logger {
   static startAppInsights() {
     if (iKey !== '') {
       applicationInsights.setup(iKey).setAutoCollectConsole(true, true);
-      applicationInsights
-        .defaultClient
-        .context
-        // eslint-disable-next-line max-len
-        .tags[applicationInsights.defaultClient.context.keys.cloudRole] = config.appInsights.roleName;
+      const client = applicationInsights.defaultClient;
+      client.context.tags[client.context.keys.cloudRole] = config.appInsights.roleName;
       applicationInsights.start();
     }
   }


### PR DESCRIPTION
This PR includes a minor refactoring in the logger.js file, but the key part is the component/product fix. This will allow the pipeline to access the correct vault (sscs-aat, sscs-prod) to pull the correct AppInsights Instrumentation Key for shared app insights.