### PR TITLE
SSCS-5710 adjust postcodelookup for save and return

### DIFF
--- a/components/postcodeLookup/content.en.json
+++ b/components/postcodeLookup/content.en.json
@@ -4,7 +4,7 @@
     "manualEntryLabel": "I can't enter a UK postcode",
     "dropdownCount": "address found",
     "fields": {
-        "postCodeLookup": {
+        "postcodeLookup": {
           "error": {
               "required": "We cannot find an address with that postcode",
               "invalidPostcode": "We cannot find an address with that postcode"

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -13,7 +13,7 @@ const { text } = require('@hmcts/one-per-page/forms');
 const Joi = require('joi');
 
 const fieldMap = {
-  postcodeLookup: 'postCodeLookup',
+  postcodeLookup: 'postcodeLookup',
   postcodeAddress: 'postcodeAddress',
   line1: 'addressLine1',
   line2: 'addressLine2',
@@ -30,7 +30,7 @@ const schemaBuilder = (fields, page) => {
     if (!includes(disabledFields, fields[i].name)) {
       if (fields[i].name === fieldMap.postcodeLookup) {
         newForm[fields[i].name] = text.joi(
-          content.fields.postCodeLookup.error.required,
+          content.fields.postcodeLookup.error.required,
           Joi.string().trim().required()
         ).joi(
           content.fields.postcodeAddress.error.required,

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -88,12 +88,11 @@ const resetSuggestions = page => {
 
 // eslint-disable-next-line max-len
 const isManualPost = page => page.req.method === 'POST' && typeof page.req.body[fieldMap.postcodeLookup] === 'undefined';
+// eslint-disable-next-line max-len
+const isManualParameter = page => page.req.query.type === 'manual' || (page.fields.type && page.fields.type.value === 'manual');
 
 const getFormType = page => {
-  const req = page.req;
-  if (req.query.type === 'manual' || !enabled || isManualPost(page) ||
-     (page.fields.type && page.fields.type.value === 'manual')
-  ) {
+  if (isManualParameter(page) || !enabled || isManualPost(page)) {
     page.postcodeLookupType = 'manual';
     return 'manual';
   }

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -154,12 +154,6 @@ const handleAddressSelection = page => {
   page.store();
 };
 
-const handleManualClick = page => {
-  manualFileds();
-  page.parse();
-  page.store();
-};
-
 const handleGetValidate = page => {
   if (page.postcodeLookupType === 'manaul' || page.addressSuggestions.length === 0) page.validate();
 };
@@ -207,7 +201,7 @@ const controller = async(page, callBack) => {
     handleAddressSelection(page);
     page.res.redirect(`${page.path}?validate=1`);
   } else if (req.body.submitType === 'manual') {
-    handleManualClick(page);
+    manualFileds();
     page.res.redirect(`${page.path}?type=manual`);
   } else if (req.method === 'GET' && req.query.validate) {
     handleGetValidate(page);

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -84,7 +84,6 @@ const alldFields = () => {
 
 const resetSuggestions = page => {
   page.addressSuggestions = [];
-  page.req.session.addressSuggestions = [];
 };
 
 // eslint-disable-next-line max-len

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -90,18 +90,13 @@ const resetSuggestions = page => {
 // eslint-disable-next-line complexity
 const getFormType = page => {
   const req = page.req;
-  if ((req.query.type && req.query.type === 'manual') || !enabled) {
+  if (req.query.type === 'manual' || !enabled) {
+    page.postcodeLookupType = 'manual';
     return 'manual';
-  } else if ((req.query.type && req.query.type === 'auto') && enabled) {
-    return 'auto';
-  } else if (req.session.postcodeLookupType === 'auto' && enabled) {
-    return 'auto';
-  } else if (req.session.postcodeLookupType === 'manual') {
-    return 'manual';
-  } else if (enabled) {
-    return 'auto';
   }
-  return 'manual';
+
+  page.postcodeLookupType = 'auto';
+  return 'auto';
 };
 
 const restoreValues = page => {
@@ -178,9 +173,6 @@ const setPageState = async page => {
   }
   const formType = getFormType(page);
   if (formType === 'auto') {
-    page.req.session.postcodeLookupType = 'auto';
-    page.postcodeLookupType = 'auto';
-
     if (page.fields[fieldMap.postcodeLookup] &&
         page.fields[fieldMap.postcodeLookup].validate() &&
         page.addressSuggestions.length > 0 &&
@@ -196,8 +188,6 @@ const setPageState = async page => {
       resetSuggestions(page);
     }
   } else {
-    page.req.session.postcodeLookupType = 'manual';
-    page.postcodeLookupType = 'manual';
     manualFileds();
   }
   restoreValues(page);

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -1,228 +1,258 @@
 const rp = require('request-promise');
-const conf = require('config');
 const { includes } = require('lodash');
 const { form } = require('@hmcts/one-per-page/forms');
-
-const url = conf.postcodeLookup.url;
-const token = conf.postcodeLookup.token;
-const enabled = conf.postcodeLookup.enabled === 'true';
 const { buildConcatenatedAddress } = require('./helper');
 const content = require('./content.en.json');
 const customFieldValidations = require('./customFieldValidations.js');
 const { text } = require('@hmcts/one-per-page/forms');
 const Joi = require('joi');
 
-const fieldMap = {
-  postcodeLookup: 'postcodeLookup',
-  postcodeAddress: 'postcodeAddress',
-  line1: 'addressLine1',
-  line2: 'addressLine2',
-  town: 'townCity',
-  county: 'county',
-  postCode: 'postCode'
-};
+class Controller {
+  constructor(enabled = true, token = '', apiUrl = '', page = {}) {
+    this.enabled = enabled;
+    this.page = page;
+    this.token = token;
+    this.apiUrl = apiUrl;
+    this.disabledFields = [];
+    this.fieldMap = {
+      postcodeLookup: 'postcodeLookup',
+      postcodeAddress: 'postcodeAddress',
+      line1: 'addressLine1',
+      line2: 'addressLine2',
+      town: 'townCity',
+      county: 'county',
+      postCode: 'postCode'
+    };
+    this.sessionName = `${page.name}.pcl`;
+  }
 
-let disabledFields = [];
-
-const schemaBuilder = (fields, page) => {
-  const newForm = Object.create(null);
-  for (let i = 0; i < fields.length; i++) {
-    if (!includes(disabledFields, fields[i].name)) {
-      if (fields[i].name === fieldMap.postcodeLookup) {
-        newForm[fields[i].name] = text.joi(
-          content.fields.postcodeLookup.error.required,
-          Joi.string().trim().required()
-        ).joi(
-          content.fields.postcodeAddress.error.required,
-          customFieldValidations.string().validateAddressList(page)
-        );
-      } else if (fields[i].name === fieldMap.postcodeAddress) {
-        newForm[fields[i].name] = text.joi(
-          content.fields.postcodeAddress.error.required,
-          Joi.string().required()
-        );
-      } else {
-        newForm[fields[i].name] = fields[i].validator;
+  schemaBuilder(fields) {
+    const newForm = Object.create(null);
+    for (let i = 0; i < fields.length; i++) {
+      if (!includes(this.disabledFields, fields[i].name)) {
+        if (fields[i].name === this.fieldMap.postcodeLookup) {
+          newForm[fields[i].name] = text.joi(
+            content.fields.postcodeLookup.error.required,
+            Joi.string().trim().required()
+          ).joi(
+            content.fields.postcodeAddress.error.required,
+            customFieldValidations.string().validateAddressList(this.page)
+          );
+        } else if (fields[i].name === this.fieldMap.postcodeAddress) {
+          newForm[fields[i].name] = text.joi(
+            content.fields.postcodeAddress.error.required,
+            Joi.string().required()
+          );
+        } else {
+          newForm[fields[i].name] = fields[i].validator;
+        }
       }
     }
+    return form(newForm);
   }
-  return form(newForm);
-};
 
-
-const postcodeLookupFields = () => {
-  disabledFields = [
-    fieldMap.postcodeAddress,
-    fieldMap.line1,
-    fieldMap.line2,
-    fieldMap.town,
-    fieldMap.county,
-    fieldMap.postCode
-  ];
-};
-
-const postcodeAddressFields = () => {
-  disabledFields = [
-    fieldMap.line1,
-    fieldMap.line2,
-    fieldMap.town,
-    fieldMap.county,
-    fieldMap.postCode
-  ];
-};
-
-const manualFileds = () => {
-  disabledFields = [
-    fieldMap.postcodeLookup,
-    fieldMap.postcodeAddress
-  ];
-};
-
-const alldFields = () => {
-  disabledFields = [];
-};
-
-const resetSuggestions = page => {
-  page.addressSuggestions = [];
-};
-
-// eslint-disable-next-line max-len
-const isManualPost = page => page.req.method === 'POST' && typeof page.req.body[fieldMap.postcodeLookup] === 'undefined';
-// eslint-disable-next-line max-len
-const isManualParameter = page => page.req.query.type === 'manual' || (page.req.session[page.name].type && page.req.session[page.name].type === 'manual');
-
-const getFormType = page => {
-  if (isManualParameter(page) || !enabled || isManualPost(page)) {
-    if (page.req.session[page.name].type) page.req.session[page.name].type = null;
-    page.postcodeLookupType = 'manual';
-    return 'manual';
+  postcodeLookupFields() {
+    const fieldMap = this.fieldMap;
+    this.disabledFields = [
+      fieldMap.postcodeAddress,
+      fieldMap.line1,
+      fieldMap.line2,
+      fieldMap.town,
+      fieldMap.county,
+      fieldMap.postCode
+    ];
+    return this.disabledFields;
   }
-  if (page.req.session[page.name].type) page.req.session[page.name].type = null;
-  page.postcodeLookupType = 'auto';
-  return 'auto';
-};
 
-const restoreValues = page => {
-  if (page.req.method === 'POST') {
-    page.parse();
-    page.store();
-  } else {
-    page.retrieve();
+  postcodeAddressFields() {
+    const fieldMap = this.fieldMap;
+    this.disabledFields = [
+      fieldMap.line1,
+      fieldMap.line2,
+      fieldMap.town,
+      fieldMap.county,
+      fieldMap.postCode
+    ];
+    return this.disabledFields;
   }
-};
 
-const handlePostCodeLookup = async page => {
-  const postCode = page.fields[fieldMap.postcodeLookup].value;
-  const options = {
-    json: true,
-    uri: `${url}/addresses/postcode?postcode=${postCode}&key=${token}`,
-    method: 'GET'
-  };
+  manualFileds() {
+    const fieldMap = this.fieldMap;
+    this.disabledFields = [
+      fieldMap.postcodeLookup,
+      fieldMap.postcodeAddress
+    ];
+    return this.disabledFields;
+  }
 
-  await rp(options).then(body => {
-    if (body.results && body.results.length > 0) {
-      page.addressSuggestions = body.results;
+  alldFields() {
+    this.disabledFields = [];
+    return this.disabledFields;
+  }
+
+  resetSuggestions() {
+    this.page.addressSuggestions = [];
+  }
+
+  isManualPost() {
+    const req = this.page.req;
+    return req.method === 'POST' && typeof req.body[this.fieldMap.postcodeLookup] === 'undefined';
+  }
+
+  isManualParameter() {
+    const req = this.page.req;
+    const page = this.page;
+    return req.query.type !== 'auto' && (req.query.type === 'manual' ||
+    (req.session[page.name] && req.session[page.name].type === 'manual') ||
+    (req.session[this.sessionName] && req.session[this.sessionName].type === 'manual'));
+  }
+
+  addTypeToSession(type = 'auto') {
+    const session = this.page.req.session;
+    session[this.sessionName] = { type };
+  }
+
+  getFormType() {
+    const page = this.page;
+    if (this.isManualParameter() || !this.enabled || this.isManualPost()) {
+      page.postcodeLookupType = 'manual';
+      this.addTypeToSession('manual');
+      return 'manual';
+    }
+
+    this.addTypeToSession('auto');
+    page.postcodeLookupType = 'auto';
+    return 'auto';
+  }
+
+  restoreValues() {
+    const page = this.page;
+    const req = this.page.req;
+    if (req.method === 'POST') {
+      page.parse();
+      page.store();
     } else {
+      page.retrieve();
+    }
+  }
+
+  async handlePostCodeLookup() {
+    const fieldMap = this.fieldMap;
+    const page = this.page;
+    const postCode = page.fields[fieldMap.postcodeLookup].value;
+    const options = {
+      json: true,
+      uri: `${this.apiUrl}/addresses/postcode?postcode=${postCode}&key=${this.token}`,
+      method: 'GET'
+    };
+
+    await rp(options).then(body => {
+      if (body.results && body.results.length > 0) {
+        page.addressSuggestions = body.results;
+      } else {
+        page.fields[fieldMap.postcodeLookup].value = '';
+      }
+      Promise.resolve();
+    }).catch(() => {
       page.fields[fieldMap.postcodeLookup].value = '';
+      Promise.resolve();
+    });
+
+    page.store();
+  }
+
+  handleAddressSelection() {
+    let selectedAddress = [];
+    const page = this.page;
+    const fieldMap = this.fieldMap;
+
+    if (page.fields[fieldMap.postcodeAddress].validate() && page.addressSuggestions) {
+      const selectedUPRN = page.fields[fieldMap.postcodeAddress].value;
+      if (selectedUPRN) {
+        // eslint-disable-next-line max-len
+        selectedAddress = page.addressSuggestions.filter(address => address.DPA.UPRN === selectedUPRN);
+      }
     }
-    Promise.resolve();
-  }).catch(() => {
-    page.fields[fieldMap.postcodeLookup].value = '';
-    Promise.resolve();
-  });
 
-  page.store();
-};
-
-const handleAddressSelection = page => {
-  let selectedAddress = [];
-  // eslint-disable-next-line max-len
-  if (page.fields[fieldMap.postcodeAddress].validate() && page.addressSuggestions) {
-    const selectedUPRN = page.fields[fieldMap.postcodeAddress].value;
-    if (selectedUPRN) {
-      // eslint-disable-next-line max-len
-      selectedAddress = page.addressSuggestions.filter(address => address.DPA.UPRN === selectedUPRN);
+    if (selectedAddress.length === 1) {
+      const concatenated = buildConcatenatedAddress(selectedAddress[0]);
+      page.fields[fieldMap.line1].value = concatenated.line1;
+      page.fields[fieldMap.line2].value = concatenated.line2;
+      page.fields[fieldMap.town].value = concatenated.town;
+      page.fields[fieldMap.county].value = concatenated.county;
+      page.fields[fieldMap.postCode].value = concatenated.postCode;
+      page.validate();
+    }
+    page.store();
+  }
+  handleGetValidate() {
+    const page = this.page;
+    if (page.postcodeLookupType === 'manaul' || page.addressSuggestions.length === 0) {
+      this.page.validate();
     }
   }
-
-  if (selectedAddress.length === 1) {
-    const concatenated = buildConcatenatedAddress(selectedAddress[0]);
-    page.fields[fieldMap.line1].value = concatenated.line1;
-    page.fields[fieldMap.line2].value = concatenated.line2;
-    page.fields[fieldMap.town].value = concatenated.town;
-    page.fields[fieldMap.county].value = concatenated.county;
-    page.fields[fieldMap.postCode].value = concatenated.postCode;
-    page.validate();
-  }
-  page.store();
-};
-
-const handleGetValidate = page => {
-  if (page.postcodeLookupType === 'manaul' || page.addressSuggestions.length === 0) page.validate();
-};
-
-// eslint-disable-next-line complexity
-const setPageState = async page => {
-  restoreValues(page);
-  // restore suggestions if they exits
-  page.addressSuggestions = [];
-  if (page.fields[fieldMap.postcodeLookup] && page.fields[fieldMap.postcodeLookup].validate()) {
-    await handlePostCodeLookup(page);
-  }
-  const formType = getFormType(page);
-  if (formType === 'auto') {
+  // eslint-disable-next-line complexity
+  async setPageState() {
+    const page = this.page;
+    const fieldMap = this.fieldMap;
+    this.restoreValues();
+    // restore suggestions if they exits
+    page.addressSuggestions = [];
     if (page.fields[fieldMap.postcodeLookup] &&
+      page.fields[fieldMap.postcodeLookup].validate()) {
+      await this.handlePostCodeLookup();
+    }
+    const formType = this.getFormType();
+    if (formType === 'auto') {
+      if (page.fields[fieldMap.postcodeLookup] &&
         page.fields[fieldMap.postcodeLookup].validate() &&
         page.addressSuggestions.length > 0 &&
         page.fields[fieldMap.postcodeAddress] &&
         page.fields[fieldMap.postcodeAddress].validate()) {
-      alldFields();
-    } else if (page.fields[fieldMap.postcodeLookup] &&
-               page.fields[fieldMap.postcodeLookup].validate() &&
-               page.addressSuggestions.length > 0) {
-      postcodeAddressFields();
+        this.alldFields();
+      } else if (page.fields[fieldMap.postcodeLookup] &&
+        page.fields[fieldMap.postcodeLookup].validate() &&
+        page.addressSuggestions.length > 0) {
+        this.postcodeAddressFields();
+      } else {
+        this.postcodeLookupFields();
+        this.resetSuggestions();
+      }
     } else {
-      postcodeLookupFields();
-      resetSuggestions(page);
+      this.manualFileds();
     }
-  } else {
-    manualFileds();
+    this.restoreValues();
   }
-  restoreValues(page);
-};
 
-// eslint-disable-next-line complexity
-const controller = async(page, callBack) => {
-  const req = page.req;
-  page.postCodeContent = content;
-  await setPageState(page);
-
-  if (req.body.submitType === 'lookup') {
-    await handlePostCodeLookup(page);
-    page.res.redirect(`${page.path}?validate=1`);
-  } else if (req.body.submitType === 'addressSelection') {
-    handleAddressSelection(page);
-    page.res.redirect(`${page.path}?validate=1`);
-  } else if (req.body.submitType === 'manual') {
-    manualFileds();
-    page.res.redirect(`${page.path}?type=manual`);
-  } else if (req.method === 'GET' && req.query.validate) {
-    handleGetValidate(page);
-    page.res.render(page.template, page.locals);
-  } else if (req.method === 'GET' && req.query.type) {
-    page.res.render(page.template, page.locals);
-  } else if (isManualPost(page) && !page.validate().valid) {
-    page.res.redirect(`${page.path}?type=manual&validate=1`);
-  } else {
-    if (typeof callBack !== 'function') {
-      throw Error('Super Callback function is not defined');
+  // eslint-disable-next-line complexity
+  async init(callBack) {
+    const req = this.page.req;
+    const page = this.page;
+    page.postCodeContent = content;
+    await this.setPageState(page);
+    if (req.body.submitType === 'lookup') {
+      await this.handlePostCodeLookup(page);
+      page.res.redirect(`${page.path}?validate=1`);
+    } else if (req.body.submitType === 'addressSelection') {
+      this.handleAddressSelection(page);
+      page.res.redirect(`${page.path}?validate=1`);
+    } else if (req.body.submitType === 'manual') {
+      this.manualFileds();
+      page.res.redirect(`${page.path}?type=manual`);
+    } else if (req.method === 'GET' && req.query.validate) {
+      this.handleGetValidate(page);
+      page.res.render(page.template, page.locals);
+    } else if (req.method === 'GET' && req.query.type) {
+      page.res.render(page.template, page.locals);
+    } else if (this.isManualPost(page) && !page.validate().valid) {
+      page.res.redirect(`${page.path}?type=manual&validate=1`);
+    } else {
+      if (typeof callBack !== 'function') {
+        throw Error('Super Callback function is not defined');
+      }
+      callBack();
     }
-    callBack();
   }
-};
+}
 
-module.exports = {
-  controller,
-  schemaBuilder,
-  fieldMap
-};
+module.exports = Controller;

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -89,15 +89,15 @@ const resetSuggestions = page => {
 // eslint-disable-next-line max-len
 const isManualPost = page => page.req.method === 'POST' && typeof page.req.body[fieldMap.postcodeLookup] === 'undefined';
 // eslint-disable-next-line max-len
-const isManualParameter = page => page.req.query.type === 'manual' || (page.fields.type && page.fields.type.value === 'manual');
+const isManualParameter = page => page.req.query.type === 'manual' || (page.req.session[page.name].type && page.req.session[page.name].type === 'manual');
 
 const getFormType = page => {
   if (isManualParameter(page) || !enabled || isManualPost(page)) {
-    if (page.fields.type) page.fields.type.value = null;
+    if (page.req.session[page.name].type) page.req.session[page.name].type = null;
     page.postcodeLookupType = 'manual';
     return 'manual';
   }
-  if (page.fields.type) page.fields.type.value = null;
+  if (page.req.session[page.name].type) page.req.session[page.name].type = null;
   page.postcodeLookupType = 'auto';
   return 'auto';
 };

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -139,7 +139,7 @@ const setPageState = async(req, page) => {
   restoreValues(page, req);
   // restore suggestions if they exits
   page.addressSuggestions = [];
-  if (page.fields[fieldMap.postcodeLookup]) {
+  if (page.fields[fieldMap.postcodeLookup] && page.fields[fieldMap.postcodeLookup].validate()) {
     await handlePostCodeLookup(page);
   }
   const formType = getFormType(req);

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -96,6 +96,10 @@ class Controller {
 
   resetSuggestions() {
     this.page.addressSuggestions = [];
+    if (this.page.fields[this.fieldMap.postcodeAddress]) {
+      this.page.fields[this.fieldMap.postcodeAddress].value = '';
+    }
+    this.page.store();
   }
 
   isManualPost() {
@@ -226,7 +230,6 @@ class Controller {
         this.postcodeAddressFields();
       } else {
         this.postcodeLookupFields();
-        this.resetSuggestions();
       }
     } else {
       this.manualFileds();
@@ -241,7 +244,7 @@ class Controller {
     page.postCodeContent = content;
     await this.setPageState(page);
     if (req.body.submitType === 'lookup') {
-      await this.handlePostCodeLookup(page);
+      this.resetSuggestions();
       page.res.redirect(`${page.path}?validate=1`);
     } else if (req.body.submitType === 'addressSelection') {
       this.handleAddressSelection(page);

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -110,35 +110,29 @@ class Controller {
     (req.session[this.sessionName] && req.session[this.sessionName].type === 'manual');
   }
 
-  addTypeToSession(type = 'auto') {
+  setMode(type = 'auto') {
     const session = this.page.req.session;
+    const page = this.page;
+    page.postcodeLookupType = type;
     session[this.sessionName] = { type };
+    return type;
   }
 
   getFormType() {
-    const page = this.page;
     const req = this.page.req;
     if (!this.enabled || req.query.type === 'manual' || this.isManualPost()) {
-      page.postcodeLookupType = 'manual';
-      this.addTypeToSession('manual');
-      return 'manual';
+      return this.setMode('manual');
     }
 
     if (this.enabled && req.query.type === 'auto') {
-      this.addTypeToSession('auto');
-      page.postcodeLookupType = 'auto';
-      return 'auto';
+      return this.setMode('auto');
     }
 
     if (this.isManualSession()) {
-      page.postcodeLookupType = 'manual';
-      this.addTypeToSession('manual');
-      return 'manual';
+      return this.setMode('manual');
     }
 
-    this.addTypeToSession('auto');
-    page.postcodeLookupType = 'auto';
-    return 'auto';
+    return this.setMode('auto');
   }
 
   restoreValues() {

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -91,7 +91,9 @@ const isManualPost = page => page.req.method === 'POST' && typeof page.req.body[
 
 const getFormType = page => {
   const req = page.req;
-  if (req.query.type === 'manual' || !enabled || isManualPost(page)) {
+  if (req.query.type === 'manual' || !enabled || isManualPost(page) ||
+     (page.fields.type && page.fields.type.value === 'manual')
+  ) {
     page.postcodeLookupType = 'manual';
     return 'manual';
   }

--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -93,9 +93,11 @@ const isManualParameter = page => page.req.query.type === 'manual' || (page.fiel
 
 const getFormType = page => {
   if (isManualParameter(page) || !enabled || isManualPost(page)) {
+    if (page.fields.type) page.fields.type.value = null;
     page.postcodeLookupType = 'manual';
     return 'manual';
   }
+  if (page.fields.type) page.fields.type.value = null;
   page.postcodeLookupType = 'auto';
   return 'auto';
 };

--- a/components/postcodeLookup/customFieldValidations.js
+++ b/components/postcodeLookup/customFieldValidations.js
@@ -12,7 +12,7 @@ const postcodeLookupJoi = Joi.extend(joi => {
         },
         validate(params, value, state, options) {
           const page = params.page;
-          const req  = page.req;
+          const req = page.req;
           const requestType = req.body.submitType ? req.body.submitType : '';
           const method = req.method;
           if (requestType === 'lookup' || requestType === 'addressSelection' || method === 'GET' ||

--- a/components/postcodeLookup/customFieldValidations.js
+++ b/components/postcodeLookup/customFieldValidations.js
@@ -12,9 +12,11 @@ const postcodeLookupJoi = Joi.extend(joi => {
         },
         validate(params, value, state, options) {
           const page = params.page;
-          if (page.req.body.submitType === 'lookup' ||
-              page.req.method === 'GET' ||
-             (page.addressSuggestions && page.addressSuggestions.length > 0)) {
+          const req  = page.req;
+          const requestType = req.body.submitType ? req.body.submitType : '';
+          const method = req.method;
+          if (requestType === 'lookup' || requestType === 'addressSelection' || method === 'GET' ||
+             (page.fields.postcodeAddress && page.fields.postcodeAddress.validate())) {
             return value;
           }
           return this.createError('string.validatePostcodeLookup', { v: value }, state, options);

--- a/components/postcodeLookup/customFieldValidations.js
+++ b/components/postcodeLookup/customFieldValidations.js
@@ -8,12 +8,13 @@ const postcodeLookupJoi = Joi.extend(joi => {
       {
         name: 'validateAddressList',
         params: {
-          req: joi.object()
+          page: joi.object()
         },
         validate(params, value, state, options) {
-          const req = params.req;
-          if (req.body.submitType === 'lookup' ||
-             (req.session.addressSuggestions && req.session.addressSuggestions.length > 0)) {
+          const page = params.page;
+          if (page.req.body.submitType === 'lookup' ||
+              page.req.method === 'GET' ||
+             (page.addressSuggestions && page.addressSuggestions.length > 0)) {
             return value;
           }
           return this.createError('string.validatePostcodeLookup', { v: value }, state, options);

--- a/components/postcodeLookup/template.html
+++ b/components/postcodeLookup/template.html
@@ -1,9 +1,9 @@
-{% macro postCodeLookup(fields, options, postcodeLookupType, content) %}
+{% macro postcodeLookup(fields, options, postcodeLookupType, content) %}
     {% if( postcodeLookupType === 'manual') %}
            {{ caller() }}
     {% else %}
         <input type="hidden" id="submitType" name="submitType" value="" />
-        {{ textboxButton(fields.postCodeLookup,  content.textboxLabel, hint="", options) }}
+        {{ textboxButton(fields.postcodeLookup,  content.textboxLabel, hint="", options) }}
         {% if options.length > 0  %}
             {{ customSelect(fields.postcodeAddress, content.addressSelectionLabel, options, content.dropdownCount) }}
         {% endif %}  

--- a/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
+++ b/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
@@ -129,10 +129,12 @@ class AppointeeContactDetails extends SaveToDraftStore {
     return {
       appointee: {
         contactDetails: {
-          // eslint-disable-next-line max-len
-          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ? decode(this.fields[pcl.fieldMap.postcodeLookup].value) : '',
-          // eslint-disable-next-line max-len
-          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ? decode(this.fields[pcl.fieldMap.postcodeAddress].value) : '',
+          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
+            decode(this.fields[pcl.fieldMap.postcodeLookup].value) :
+            '',
+          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ?
+            decode(this.fields[pcl.fieldMap.postcodeAddress].value) :
+            '',
           addressLine1: decode(this.fields.addressLine1.value),
           addressLine2: decode(this.fields.addressLine2.value),
           townCity: decode(this.fields.townCity.value),

--- a/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
+++ b/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
@@ -129,7 +129,7 @@ class AppointeeContactDetails extends SaveToDraftStore {
     return {
       appointee: {
         contactDetails: {
-          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
+          postcodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
             decode(this.fields[pcl.fieldMap.postcodeLookup].value) :
             '',
           postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ?

--- a/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
+++ b/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
@@ -80,7 +80,7 @@ class AppointeeContactDetails extends SaveToDraftStore {
           fields.emailAddress.error.invalid,
           Joi.string().trim().email(emailOptions).allow('')
         ) }
-    ], this.req);
+    ], this);
   }
 
   static isEnglandOrWalesPostcode(req, resp, next) {
@@ -129,6 +129,10 @@ class AppointeeContactDetails extends SaveToDraftStore {
     return {
       appointee: {
         contactDetails: {
+          // eslint-disable-next-line max-len
+          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ? decode(this.fields[pcl.fieldMap.postcodeLookup].value) : '',
+          // eslint-disable-next-line max-len
+          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ? decode(this.fields[pcl.fieldMap.postcodeAddress].value) : '',
           addressLine1: decode(this.fields.addressLine1.value),
           addressLine2: decode(this.fields.addressLine2.value),
           townCity: decode(this.fields.townCity.value),

--- a/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
+++ b/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
@@ -25,7 +25,7 @@ class AppointeeContactDetails extends SaveToDraftStore {
   }
 
   handler(req, res, next) {
-    pcl.controller(req, res, next, this, super.handler);
+    pcl.controller(this, () => super.handler(req, res, next));
   }
 
   get CYAPhoneNumber() {

--- a/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
+++ b/steps/appointee/appointee-contact-details/AppointeeContactDetails.js
@@ -16,16 +16,26 @@ const config = require('config');
 const customJoi = require('utils/customJoiSchemas');
 
 const usePostcodeChecker = config.get('postcodeChecker.enabled');
-const pcl = require('components/postcodeLookup/controller');
+
 const { decode } = require('utils/stringUtils');
 
+const PCL = require('components/postcodeLookup/controller');
+
+const url = config.postcodeLookup.url;
+const token = config.postcodeLookup.token;
+const enabled = config.postcodeLookup.enabled === 'true';
+
 class AppointeeContactDetails extends SaveToDraftStore {
+  constructor(...args) {
+    super(...args);
+    this.pcl = new PCL(enabled, token, url, this);
+  }
   static get path() {
     return paths.appointee.enterAppointeeContactDetails;
   }
 
   handler(req, res, next) {
-    pcl.controller(this, () => super.handler(req, res, next));
+    this.pcl.init(() => super.handler(req, res, next));
   }
 
   get CYAPhoneNumber() {
@@ -39,30 +49,30 @@ class AppointeeContactDetails extends SaveToDraftStore {
   get form() {
     const fields = this.content.fields;
 
-    return pcl.schemaBuilder([
-      { name: pcl.fieldMap.postcodeLookup },
-      { name: pcl.fieldMap.postcodeAddress },
-      { name: pcl.fieldMap.line1,
+    return this.pcl.schemaBuilder([
+      { name: this.pcl.fieldMap.postcodeLookup },
+      { name: this.pcl.fieldMap.postcodeAddress },
+      { name: this.pcl.fieldMap.line1,
         validator: text.joi(
           fields.addressLine1.error.required,
           Joi.string().regex(whitelist).required()
         ) },
-      { name: pcl.fieldMap.line2,
+      { name: this.pcl.fieldMap.line2,
         validator: text.joi(
           fields.addressLine2.error.invalid,
           Joi.string().regex(whitelist).allow('')
         ) },
-      { name: pcl.fieldMap.town,
+      { name: this.pcl.fieldMap.town,
         validator: text.joi(
           fields.townCity.error.required,
           Joi.string().regex(whitelist).required()
         ) },
-      { name: pcl.fieldMap.county,
+      { name: this.pcl.fieldMap.county,
         validator: text.joi(
           fields.county.error.required,
           Joi.string().regex(whitelist).required()
         ) },
-      { name: pcl.fieldMap.postCode,
+      { name: this.pcl.fieldMap.postCode,
         validator: text.joi(
           fields.postCode.error.required,
           Joi.string().trim().regex(postCode).required()
@@ -80,7 +90,7 @@ class AppointeeContactDetails extends SaveToDraftStore {
           fields.emailAddress.error.invalid,
           Joi.string().trim().email(emailOptions).allow('')
         ) }
-    ], this);
+    ]);
   }
 
   static isEnglandOrWalesPostcode(req, resp, next) {
@@ -129,11 +139,11 @@ class AppointeeContactDetails extends SaveToDraftStore {
     return {
       appointee: {
         contactDetails: {
-          postcodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
-            decode(this.fields[pcl.fieldMap.postcodeLookup].value) :
+          postcodeLookup: this.fields[this.pcl.fieldMap.postcodeLookup] ?
+            decode(this.fields[this.pcl.fieldMap.postcodeLookup].value) :
             '',
-          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ?
-            decode(this.fields[pcl.fieldMap.postcodeAddress].value) :
+          postcodeAddress: this.fields[this.pcl.fieldMap.postcodeAddress] ?
+            decode(this.fields[this.pcl.fieldMap.postcodeAddress].value) :
             '',
           addressLine1: decode(this.fields.addressLine1.value),
           addressLine2: decode(this.fields.addressLine2.value),

--- a/steps/appointee/appointee-contact-details/template.html
+++ b/steps/appointee/appointee-contact-details/template.html
@@ -1,6 +1,6 @@
 {% extends "components/form-template.html" %}
 {% from "look-and-feel/components/fields.njk" import textbox, formSection %}
-{% from "postcodeLookup/template.html" import postCodeLookup  %}
+{% from "postcodeLookup/template.html" import postcodeLookup  %}
 
 {% block page_title %}{{ content.titleHead }}{% endblock %}
 
@@ -14,7 +14,7 @@
 
         <p>{{ content.subtitle}}</p>
 
-        {% call postCodeLookup(fields, addressSuggestions, postcodeLookupType, postCodeContent) %}
+        {% call postcodeLookup(fields, addressSuggestions, postcodeLookupType, postCodeContent) %}
 
             {{ textbox(fields.addressLine1,         content.fields.addressLine1.title,          hint="") }}
             {{ textbox(fields.addressLine2,         content.fields.addressLine2.title,          hint="") }}

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -152,10 +152,12 @@ class AppellantContactDetails extends SaveToDraftStore {
     return {
       appellant: {
         contactDetails: {
-          // eslint-disable-next-line max-len
-          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ? decode(this.fields[pcl.fieldMap.postcodeLookup].value) : '',
-          // eslint-disable-next-line max-len
-          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ? decode(this.fields[pcl.fieldMap.postcodeAddress].value) : '',
+          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
+            decode(this.fields[pcl.fieldMap.postcodeLookup].value) :
+            '',
+          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ?
+            decode(this.fields[pcl.fieldMap.postcodeAddress].value) :
+            '',
           addressLine1: decode(this.fields.addressLine1.value),
           addressLine2: decode(this.fields.addressLine2.value),
           townCity: decode(this.fields.townCity.value),

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -19,15 +19,24 @@ const config = require('config');
 const { decode } = require('utils/stringUtils');
 
 const usePostcodeChecker = config.get('postcodeChecker.enabled');
-const pcl = require('components/postcodeLookup/controller');
+const PCL = require('components/postcodeLookup/controller');
+
+const url = config.postcodeLookup.url;
+const token = config.postcodeLookup.token;
+const enabled = config.postcodeLookup.enabled === 'true';
 
 class AppellantContactDetails extends SaveToDraftStore {
+  constructor(...args) {
+    super(...args);
+    this.pcl = new PCL(enabled, token, url, this);
+  }
+
   static get path() {
     return paths.identity.enterAppellantContactDetails;
   }
 
   handler(req, res, next) {
-    pcl.controller(this, () => super.handler(req, res, next));
+    this.pcl.init(() => super.handler(req, res, next));
   }
 
   isAppointee() {
@@ -62,30 +71,30 @@ class AppellantContactDetails extends SaveToDraftStore {
     const fields = this.content.fields;
     const prefix = this.contentPrefix();
 
-    return pcl.schemaBuilder([
-      { name: pcl.fieldMap.postcodeLookup },
-      { name: pcl.fieldMap.postcodeAddress },
-      { name: pcl.fieldMap.line1,
+    return this.pcl.schemaBuilder([
+      { name: this.pcl.fieldMap.postcodeLookup },
+      { name: this.pcl.fieldMap.postcodeAddress },
+      { name: this.pcl.fieldMap.line1,
         validator: text.joi(
           fields.addressLine1.error[prefix].required,
           Joi.string().regex(whitelist).required()
         ) },
-      { name: pcl.fieldMap.line2,
+      { name: this.pcl.fieldMap.line2,
         validator: text.joi(
           fields.addressLine2.error[prefix].invalid,
           Joi.string().regex(whitelist).allow('')
         ) },
-      { name: pcl.fieldMap.town,
+      { name: this.pcl.fieldMap.town,
         validator: text.joi(
           fields.townCity.error[prefix].required,
           Joi.string().regex(whitelist).required()
         ) },
-      { name: pcl.fieldMap.county,
+      { name: this.pcl.fieldMap.county,
         validator: text.joi(
           fields.county.error[prefix].required,
           Joi.string().regex(whitelist).required()
         ) },
-      { name: pcl.fieldMap.postCode,
+      { name: this.pcl.fieldMap.postCode,
         validator: text.joi(
           fields.postCode.error[prefix].required,
           Joi.string().trim().regex(postCode).required()
@@ -103,7 +112,7 @@ class AppellantContactDetails extends SaveToDraftStore {
           fields.emailAddress.error[prefix].invalid,
           Joi.string().trim().email(emailOptions).allow('')
         ) }
-    ], this);
+    ]);
   }
 
   static isEnglandOrWalesPostcode(req, resp, next) {
@@ -152,11 +161,11 @@ class AppellantContactDetails extends SaveToDraftStore {
     return {
       appellant: {
         contactDetails: {
-          postcodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
-            decode(this.fields[pcl.fieldMap.postcodeLookup].value) :
+          postcodeLookup: this.fields[this.pcl.fieldMap.postcodeLookup] ?
+            decode(this.fields[this.pcl.fieldMap.postcodeLookup].value) :
             '',
-          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ?
-            decode(this.fields[pcl.fieldMap.postcodeAddress].value) :
+          postcodeAddress: this.fields[this.pcl.fieldMap.postcodeAddress] ?
+            decode(this.fields[this.pcl.fieldMap.postcodeAddress].value) :
             '',
           addressLine1: decode(this.fields.addressLine1.value),
           addressLine2: decode(this.fields.addressLine2.value),

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -103,7 +103,7 @@ class AppellantContactDetails extends SaveToDraftStore {
           fields.emailAddress.error[prefix].invalid,
           Joi.string().trim().email(emailOptions).allow('')
         ) }
-    ], this.req);
+    ], this);
   }
 
   static isEnglandOrWalesPostcode(req, resp, next) {
@@ -152,6 +152,10 @@ class AppellantContactDetails extends SaveToDraftStore {
     return {
       appellant: {
         contactDetails: {
+          // eslint-disable-next-line max-len
+          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ? decode(this.fields[pcl.fieldMap.postcodeLookup].value) : '',
+          // eslint-disable-next-line max-len
+          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ? decode(this.fields[pcl.fieldMap.postcodeAddress].value) : '',
           addressLine1: decode(this.fields.addressLine1.value),
           addressLine2: decode(this.fields.addressLine2.value),
           townCity: decode(this.fields.townCity.value),

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -27,7 +27,7 @@ class AppellantContactDetails extends SaveToDraftStore {
   }
 
   handler(req, res, next) {
-    pcl.controller(req, res, next, this, super.handler);
+    pcl.controller(this, () => super.handler(req, res, next));
   }
 
   isAppointee() {

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -167,7 +167,7 @@ class AppellantContactDetails extends SaveToDraftStore {
             this.fields.phoneNumber.value.trim() :
             this.fields.phoneNumber.value,
           emailAddress: this.fields.emailAddress.value
-          
+
         }
       }
     };

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -167,6 +167,7 @@ class AppellantContactDetails extends SaveToDraftStore {
             this.fields.phoneNumber.value.trim() :
             this.fields.phoneNumber.value,
           emailAddress: this.fields.emailAddress.value
+          
         }
       }
     };

--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -152,7 +152,7 @@ class AppellantContactDetails extends SaveToDraftStore {
     return {
       appellant: {
         contactDetails: {
-          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
+          postcodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
             decode(this.fields[pcl.fieldMap.postcodeLookup].value) :
             '',
           postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ?

--- a/steps/identity/appellant-contact-details/template.html
+++ b/steps/identity/appellant-contact-details/template.html
@@ -1,6 +1,6 @@
 {% extends "components/form-template.html" %}
 {% from "look-and-feel/components/fields.njk" import textbox, formSection %}
-{% from "postcodeLookup/template.html" import postCodeLookup  %}
+{% from "postcodeLookup/template.html" import postcodeLookup  %}
 
 {% block page_title %}{{ content.titleHead }}{% endblock %}
 
@@ -13,7 +13,7 @@
     {% call formSection() %}
 
         <p>{{ subtitle}}</p>
-        {% call postCodeLookup(fields, addressSuggestions, postcodeLookupType, postCodeContent) %}
+        {% call postcodeLookup(fields, addressSuggestions, postcodeLookupType, postCodeContent) %}
             {{ textbox(fields.addressLine1,         content.fields.addressLine1.title,          hint="") }}
             {{ textbox(fields.addressLine2,         content.fields.addressLine2.title,          hint="") }}
             {{ textbox(fields.townCity,             content.fields.townCity.title,              hint="") }}

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -146,7 +146,7 @@ class RepresentativeDetails extends SaveToDraftStore {
         lastName: decode(this.fields.name.last.value),
         organisation: decode(this.fields.name.organisation.value),
         contactDetails: {
-          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
+          postcodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
             decode(this.fields[pcl.fieldMap.postcodeLookup].value) :
             '',
           postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ?

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -31,7 +31,7 @@ class RepresentativeDetails extends SaveToDraftStore {
   }
 
   handler(req, res, next) {
-    pcl.controller(req, res, next, this, super.handler);
+    pcl.controller(this, () => super.handler(req, res, next));
   }
 
   get CYAName() {

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -126,7 +126,7 @@ class RepresentativeDetails extends SaveToDraftStore {
           fields.emailAddress.error.invalid,
           Joi.string().trim().email(emailOptions).allow('')
         ) }
-    ], this.req);
+    ], this);
   }
 
   answers() {
@@ -146,6 +146,10 @@ class RepresentativeDetails extends SaveToDraftStore {
         lastName: decode(this.fields.name.last.value),
         organisation: decode(this.fields.name.organisation.value),
         contactDetails: {
+          // eslint-disable-next-line max-len
+          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ? decode(this.fields[pcl.fieldMap.postcodeLookup].value) : '',
+          // eslint-disable-next-line max-len
+          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ? decode(this.fields[pcl.fieldMap.postcodeAddress].value) : '',
           addressLine1: decode(this.fields.addressLine1.value),
           addressLine2: decode(this.fields.addressLine2.value),
           townCity: decode(this.fields.townCity.value),

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -146,10 +146,12 @@ class RepresentativeDetails extends SaveToDraftStore {
         lastName: decode(this.fields.name.last.value),
         organisation: decode(this.fields.name.organisation.value),
         contactDetails: {
-          // eslint-disable-next-line max-len
-          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ? decode(this.fields[pcl.fieldMap.postcodeLookup].value) : '',
-          // eslint-disable-next-line max-len
-          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ? decode(this.fields[pcl.fieldMap.postcodeAddress].value) : '',
+          postCodeLookup: this.fields[pcl.fieldMap.postcodeLookup] ?
+            decode(this.fields[pcl.fieldMap.postcodeLookup].value) :
+            '',
+          postcodeAddress: this.fields[pcl.fieldMap.postcodeAddress] ?
+            decode(this.fields[pcl.fieldMap.postcodeAddress].value) :
+            '',
           addressLine1: decode(this.fields.addressLine1.value),
           addressLine2: decode(this.fields.addressLine2.value),
           townCity: decode(this.fields.townCity.value),

--- a/steps/representative/representative-details/template.html
+++ b/steps/representative/representative-details/template.html
@@ -1,6 +1,6 @@
 {% extends "components/form-template.html" %}
 {% from "look-and-feel/components/fields.njk" import textbox, formSection, errorClass, errorsFor %}
-{% from "postcodeLookup/template.html" import postCodeLookup  %}
+{% from "postcodeLookup/template.html" import postcodeLookup  %}
 
 {% block page_title %}{{ content.titleHead }}{% endblock %}
 
@@ -24,7 +24,7 @@
             {{ textbox(fields.name.organisation, content.fields.name.organisation.title) }}
 
         </fieldset>
-        {% call postCodeLookup(fields, addressSuggestions, postcodeLookupType, postCodeContent) %}
+        {% call postcodeLookup(fields, addressSuggestions, postcodeLookupType, postCodeContent) %}
             {{ textbox(fields.addressLine1, content.fields.addressLine1.title,  hint=content.fields.addressLine1.hint) }}
             {{ textbox(fields.addressLine2, content.fields.addressLine2.title) }}
             {{ textbox(fields.townCity,     content.fields.townCity.title) }}

--- a/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
+++ b/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
@@ -58,6 +58,7 @@ describe('Appointee-contact-details.js', () => {
     const redirect = sinon.spy();
     const res = { redirect };
     it('call pcl controller once', () => {
+      appointeeContactDetails.req = req;
       appointeeContactDetails.handler(req, res, next);
       expect(pclSpy).to.have.been.calledOnce;
     });

--- a/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
+++ b/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
@@ -323,7 +323,7 @@ describe('Appointee-contact-details.js', () => {
       appointeeContactDetails.fields.emailAddress.value = 'myemailaddress@sscs.com';
       appointeeContactDetails.fields.postcodeLookup.value = 'n29ed';
       appointeeContactDetails.fields.postcodeAddress.value = '200000';
-    
+
       let values = appointeeContactDetails.values();
       expect(values).to.eql({
         appointee: {
@@ -360,7 +360,6 @@ describe('Appointee-contact-details.js', () => {
           }
         }
       });
-
     });
 
     it('should contain an empty object', () => {

--- a/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
+++ b/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
@@ -324,7 +324,7 @@ describe('Appointee-contact-details.js', () => {
       appointeeContactDetails.fields.postcodeLookup.value = 'n29ed';
       appointeeContactDetails.fields.postcodeAddress.value = '200000';
 
-      let values = appointeeContactDetails.values();
+      const values = appointeeContactDetails.values();
       expect(values).to.eql({
         appointee: {
           contactDetails: {
@@ -340,29 +340,11 @@ describe('Appointee-contact-details.js', () => {
           }
         }
       });
-
-      appointeeContactDetails.fields.postcodeLookup = undefined;
-      appointeeContactDetails.fields.postcodeAddress = undefined;
-
-      values = appointeeContactDetails.values();
-      expect(values).to.eql({
-        appointee: {
-          contactDetails: {
-            addressLine1: 'First line of my address',
-            addressLine2: 'Second line of my address',
-            townCity: 'Town or City',
-            county: 'County',
-            postCode: 'Postcode',
-            postcodeLookup: '',
-            postcodeAddress: '',
-            phoneNumber: '0800109756',
-            emailAddress: 'myemailaddress@sscs.com'
-          }
-        }
-      });
     });
 
     it('should contain an empty object', () => {
+      appointeeContactDetails.fields.postcodeLookup = undefined;
+      appointeeContactDetails.fields.postcodeAddress = undefined;
       const values = appointeeContactDetails.values();
       expect(values).to.deep.equal({
         appointee: {

--- a/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
+++ b/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
@@ -6,7 +6,6 @@ const paths = require('paths');
 const userAnswer = require('utils/answer');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const pcl = require('components/postcodeLookup/controller');
 const config = require('config');
 
 describe('Appointee-contact-details.js', () => {
@@ -48,11 +47,11 @@ describe('Appointee-contact-details.js', () => {
     let pclSpy = '';
 
     beforeEach(() => {
-      pclSpy = sinon.spy(pcl, 'controller');
+      pclSpy = sinon.spy(appointeeContactDetails.pcl, 'init');
     });
 
     afterEach(() => {
-      pcl.controller.restore();
+      appointeeContactDetails.pcl.init.restore();
     });
 
     const req = { method: 'GET', body: {}, session: {}, query: {} };
@@ -167,6 +166,13 @@ describe('Appointee-contact-details.js', () => {
 
     describe('all field names', () => {
       it('should contain dynamic fields', () => {
+        const req = { method: 'GET', body: {}, session: {}, query: {} };
+        const next = sinon.spy();
+        const redirect = sinon.spy();
+        const res = { redirect };
+        appointeeContactDetails.req = req;
+        appointeeContactDetails.handler(req, res, next);
+        fields = appointeeContactDetails.form.fields;
         if (isPostCodeLookupEnabled) {
           expect(Object.keys(fields).length).to.equal(3);
           expect(fields).to.have.all.keys(

--- a/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
+++ b/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
@@ -341,8 +341,8 @@ describe('Appointee-contact-details.js', () => {
         }
       });
 
-      appointeeContactDetails.fields.postcodeLookup.value = '';
-      appointeeContactDetails.fields.postcodeAddress.value = '';
+      appointeeContactDetails.fields.postcodeLookup = undefined;
+      appointeeContactDetails.fields.postcodeAddress = undefined;
 
       values = appointeeContactDetails.values();
       expect(values).to.eql({

--- a/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
+++ b/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
@@ -53,7 +53,7 @@ describe('Appointee-contact-details.js', () => {
       pcl.controller.restore();
     });
 
-    const req = { method: 'POST', body: {}, session: {}, query: {} };
+    const req = { method: 'GET', body: {}, session: {}, query: {} };
     const next = sinon.spy();
     const redirect = sinon.spy();
     const res = { redirect };
@@ -327,6 +327,8 @@ describe('Appointee-contact-details.js', () => {
             townCity: 'Town or City',
             county: 'County',
             postCode: 'Postcode',
+            postCodeLookup: '',
+            postcodeAddress: '',
             phoneNumber: '0800109756',
             emailAddress: 'myemailaddress@sscs.com'
           }
@@ -344,6 +346,8 @@ describe('Appointee-contact-details.js', () => {
             townCity: '',
             county: '',
             postCode: '',
+            postCodeLookup: '',
+            postcodeAddress: '',
             phoneNumber: undefined,
             emailAddress: ''
           }

--- a/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
+++ b/test/unit/steps/appointee/appointee-contact-details/Appointee-contact-details.test.js
@@ -32,7 +32,9 @@ describe('Appointee-contact-details.js', () => {
       county: { value: '' },
       postCode: { value: '' },
       phoneNumber: {},
-      emailAddress: { value: '' }
+      emailAddress: { value: '' },
+      postcodeLookup: { value: '' },
+      postcodeAddress: { value: '' }
     };
   });
 
@@ -170,7 +172,7 @@ describe('Appointee-contact-details.js', () => {
           expect(fields).to.have.all.keys(
             'phoneNumber',
             'emailAddress',
-            'postCodeLookup');
+            'postcodeLookup');
         } else {
           expect(Object.keys(fields).length).to.equal(7);
           expect(fields).to.have.all.keys(
@@ -319,7 +321,10 @@ describe('Appointee-contact-details.js', () => {
       appointeeContactDetails.fields.postCode.value = 'Postcode';
       appointeeContactDetails.fields.phoneNumber.value = '0800109756';
       appointeeContactDetails.fields.emailAddress.value = 'myemailaddress@sscs.com';
-      const values = appointeeContactDetails.values();
+      appointeeContactDetails.fields.postcodeLookup.value = 'n29ed';
+      appointeeContactDetails.fields.postcodeAddress.value = '200000';
+    
+      let values = appointeeContactDetails.values();
       expect(values).to.eql({
         appointee: {
           contactDetails: {
@@ -328,13 +333,34 @@ describe('Appointee-contact-details.js', () => {
             townCity: 'Town or City',
             county: 'County',
             postCode: 'Postcode',
-            postCodeLookup: '',
+            postcodeLookup: 'n29ed',
+            postcodeAddress: '200000',
+            phoneNumber: '0800109756',
+            emailAddress: 'myemailaddress@sscs.com'
+          }
+        }
+      });
+
+      appointeeContactDetails.fields.postcodeLookup.value = '';
+      appointeeContactDetails.fields.postcodeAddress.value = '';
+
+      values = appointeeContactDetails.values();
+      expect(values).to.eql({
+        appointee: {
+          contactDetails: {
+            addressLine1: 'First line of my address',
+            addressLine2: 'Second line of my address',
+            townCity: 'Town or City',
+            county: 'County',
+            postCode: 'Postcode',
+            postcodeLookup: '',
             postcodeAddress: '',
             phoneNumber: '0800109756',
             emailAddress: 'myemailaddress@sscs.com'
           }
         }
       });
+
     });
 
     it('should contain an empty object', () => {
@@ -347,7 +373,7 @@ describe('Appointee-contact-details.js', () => {
             townCity: '',
             county: '',
             postCode: '',
-            postCodeLookup: '',
+            postcodeLookup: '',
             postcodeAddress: '',
             phoneNumber: undefined,
             emailAddress: ''

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -6,7 +6,6 @@ const paths = require('paths');
 const userAnswer = require('utils/answer');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const pcl = require('components/postcodeLookup/controller');
 const config = require('config');
 
 
@@ -49,11 +48,11 @@ describe('AppellantContactDetails.js', () => {
     let pclSpy = '';
 
     beforeEach(() => {
-      pclSpy = sinon.spy(pcl, 'controller');
+      pclSpy = sinon.spy(appellantContactDetails.pcl, 'init');
     });
 
     afterEach(() => {
-      pcl.controller.restore();
+      appellantContactDetails.pcl.init.restore();
     });
 
     const req = { method: 'GET', body: {}, session: {}, query: {} };
@@ -163,6 +162,13 @@ describe('AppellantContactDetails.js', () => {
 
     describe('all field names', () => {
       it('should contain dynamic fields', () => {
+        const req = { method: 'GET', body: {}, session: {}, query: {} };
+        const next = sinon.spy();
+        const redirect = sinon.spy();
+        const res = { redirect };
+        appellantContactDetails.req = req;
+        appellantContactDetails.handler(req, res, next);
+        fields = appellantContactDetails.form.fields;
         if (isPostCodeLookupEnabled) {
           expect(Object.keys(fields).length).to.equal(3);
           expect(fields).to.have.all.keys(

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -319,7 +319,7 @@ describe('AppellantContactDetails.js', () => {
       appellantContactDetails.fields.emailAddress.value = 'myemailaddress@sscs.com';
       appellantContactDetails.fields.postcodeLookup.value = 'n29ed';
       appellantContactDetails.fields.postcodeAddress.value = '200000';
-      let values = appellantContactDetails.values();
+      const values = appellantContactDetails.values();
       expect(values).to.eql({
         appellant: {
           contactDetails: {
@@ -335,22 +335,25 @@ describe('AppellantContactDetails.js', () => {
           }
         }
       });
+    });
+
+    it('should empty a value object', () => {
       appellantContactDetails.fields.postcodeLookup = undefined;
       appellantContactDetails.fields.postcodeAddress = undefined;
+      const values = appellantContactDetails.values();
 
-      values = appellantContactDetails.values();
       expect(values).to.eql({
         appellant: {
           contactDetails: {
-            addressLine1: 'First line of my address',
-            addressLine2: 'Second line of my address',
-            townCity: 'Town or City',
-            county: 'County',
-            postCode: 'Postcode',
+            addressLine1: '',
+            addressLine2: '',
+            townCity: '',
+            county: '',
+            postCode: '',
             postcodeLookup: '',
             postcodeAddress: '',
-            phoneNumber: '0800109756',
-            emailAddress: 'myemailaddress@sscs.com'
+            phoneNumber: undefined,
+            emailAddress: ''
           }
         }
       });

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -335,8 +335,8 @@ describe('AppellantContactDetails.js', () => {
           }
         }
       });
-      appellantContactDetails.fields.postcodeLookup.value = null;
-      appellantContactDetails.fields.postcodeAddress.value = null;
+      appellantContactDetails.fields.postcodeLookup = undefined;
+      appellantContactDetails.fields.postcodeAddress = undefined;
 
       values = appellantContactDetails.values();
       expect(values).to.eql({

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -33,7 +33,9 @@ describe('AppellantContactDetails.js', () => {
       county: { value: '' },
       postCode: { value: '' },
       phoneNumber: {},
-      emailAddress: { value: '' }
+      emailAddress: { value: '' },
+      postcodeLookup: { value: '' },
+      postcodeAddress: { value: '' }
     };
   });
 
@@ -166,7 +168,7 @@ describe('AppellantContactDetails.js', () => {
           expect(fields).to.have.all.keys(
             'phoneNumber',
             'emailAddress',
-            'postCodeLookup');
+            'postcodeLookup');
         } else {
           expect(Object.keys(fields).length).to.equal(7);
           expect(fields).to.have.all.keys(
@@ -315,7 +317,9 @@ describe('AppellantContactDetails.js', () => {
       appellantContactDetails.fields.postCode.value = 'Postcode';
       appellantContactDetails.fields.phoneNumber.value = '0800109756';
       appellantContactDetails.fields.emailAddress.value = 'myemailaddress@sscs.com';
-      const values = appellantContactDetails.values();
+      appellantContactDetails.fields.postcodeLookup.value = 'n29ed';
+      appellantContactDetails.fields.postcodeAddress.value = '200000';
+      let values = appellantContactDetails.values();
       expect(values).to.eql({
         appellant: {
           contactDetails: {
@@ -324,7 +328,26 @@ describe('AppellantContactDetails.js', () => {
             townCity: 'Town or City',
             county: 'County',
             postCode: 'Postcode',
-            postCodeLookup: '',
+            postcodeLookup: 'n29ed',
+            postcodeAddress: '200000',
+            phoneNumber: '0800109756',
+            emailAddress: 'myemailaddress@sscs.com'
+          }
+        }
+      });
+      appellantContactDetails.fields.postcodeLookup.value = null;
+      appellantContactDetails.fields.postcodeAddress.value = null;
+
+      values = appellantContactDetails.values();
+      expect(values).to.eql({
+        appellant: {
+          contactDetails: {
+            addressLine1: 'First line of my address',
+            addressLine2: 'Second line of my address',
+            townCity: 'Town or City',
+            county: 'County',
+            postCode: 'Postcode',
+            postcodeLookup: '',
             postcodeAddress: '',
             phoneNumber: '0800109756',
             emailAddress: 'myemailaddress@sscs.com'

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -59,6 +59,7 @@ describe('AppellantContactDetails.js', () => {
     const redirect = sinon.spy();
     const res = { redirect };
     it('call pcl controller once', () => {
+      appellantContactDetails.req = req;
       appellantContactDetails.handler(req, res, next);
       expect(pclSpy).to.have.been.calledOnce;
     });

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -323,6 +323,8 @@ describe('AppellantContactDetails.js', () => {
             townCity: 'Town or City',
             county: 'County',
             postCode: 'Postcode',
+            postCodeLookup: '',
+            postcodeAddress: '',
             phoneNumber: '0800109756',
             emailAddress: 'myemailaddress@sscs.com'
           }

--- a/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
+++ b/test/unit/steps/identity/appellant-details/AppellantContactDetails.test.js
@@ -54,7 +54,7 @@ describe('AppellantContactDetails.js', () => {
       pcl.controller.restore();
     });
 
-    const req = { method: 'POST', body: {}, session: {}, query: {} };
+    const req = { method: 'GET', body: {}, session: {}, query: {} };
     const next = sinon.spy();
     const redirect = sinon.spy();
     const res = { redirect };

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -341,6 +341,8 @@ describe('RepresentativeDetails.js', () => {
             townCity: 'Town or City',
             county: 'County',
             postCode: 'Postcode',
+            postCodeLookup: '',
+            postcodeAddress: '',
             phoneNumber: '0800109756',
             emailAddress: 'myemailaddress@sscs.com'
           }

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -331,7 +331,7 @@ describe('RepresentativeDetails.js', () => {
       representativeDetails.fields.emailAddress.value = 'myemailaddress@sscs.com';
       representativeDetails.fields.postcodeLookup.value = 'n29ed';
       representativeDetails.fields.postcodeAddress.value = '200000';
-      let values = representativeDetails.values();
+      const values = representativeDetails.values();
       expect(values).to.eql({
         representative: {
           title: 'Title',
@@ -351,30 +351,33 @@ describe('RepresentativeDetails.js', () => {
           }
         }
       });
+    });
 
+    it('should contain empty object', () => {
       representativeDetails.fields.postcodeLookup = undefined;
       representativeDetails.fields.postcodeAddress = undefined;
-      values = representativeDetails.values();
+      const values = representativeDetails.values();
       expect(values).to.eql({
         representative: {
-          title: 'Title',
-          firstName: 'First name',
-          lastName: 'Last name',
-          organisation: 'Organisation',
+          title: '',
+          firstName: '',
+          lastName: '',
+          organisation: '',
           contactDetails: {
-            addressLine1: 'First line of my address',
-            addressLine2: 'Second line of my address',
-            townCity: 'Town or City',
-            county: 'County',
-            postCode: 'Postcode',
+            addressLine1: '',
+            addressLine2: '',
+            townCity: '',
+            county: '',
+            postCode: '',
             postcodeLookup: '',
             postcodeAddress: '',
-            phoneNumber: '0800109756',
-            emailAddress: 'myemailaddress@sscs.com'
+            phoneNumber: '',
+            emailAddress: ''
           }
         }
       });
     });
+
     it('removes whitespace from before and after the postcode string', () => {
       representativeDetails.fields.postCode.value = ' Post code ';
       const postcode = representativeDetails.values().representative.contactDetails.postCode;

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -58,7 +58,7 @@ describe('RepresentativeDetails.js', () => {
       pcl.controller.restore();
     });
 
-    const req = { method: 'POST', body: {}, session: {}, query: {} };
+    const req = { method: 'GET', body: {}, session: {}, query: {} };
     const next = sinon.spy();
     const redirect = sinon.spy();
     const res = { redirect };

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -352,8 +352,8 @@ describe('RepresentativeDetails.js', () => {
         }
       });
 
-      representativeDetails.fields.postcodeLookup.value = null;
-      representativeDetails.fields.postcodeAddress.value = null;
+      representativeDetails.fields.postcodeLookup = undefined;
+      representativeDetails.fields.postcodeAddress = undefined;
       values = representativeDetails.values();
       expect(values).to.eql({
         representative: {

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -160,7 +160,7 @@ describe('RepresentativeDetails.js', () => {
           'name',
           'emailAddress',
           'phoneNumber',
-          'postCodeLookup'
+          'postcodeLookup'
         );
       } else {
         expect(Object.keys(fields).length).to.equal(8);
@@ -329,7 +329,9 @@ describe('RepresentativeDetails.js', () => {
       representativeDetails.fields.postCode.value = 'Postcode';
       representativeDetails.fields.phoneNumber.value = '0800109756';
       representativeDetails.fields.emailAddress.value = 'myemailaddress@sscs.com';
-      const values = representativeDetails.values();
+      representativeDetails.fields.postcodeLookup.value = 'n29ed';
+      representativeDetails.fields.postcodeAddress.value = '200000';
+      let values = representativeDetails.values();
       expect(values).to.eql({
         representative: {
           title: 'Title',
@@ -342,7 +344,30 @@ describe('RepresentativeDetails.js', () => {
             townCity: 'Town or City',
             county: 'County',
             postCode: 'Postcode',
-            postCodeLookup: '',
+            postcodeLookup: 'n29ed',
+            postcodeAddress: '200000',
+            phoneNumber: '0800109756',
+            emailAddress: 'myemailaddress@sscs.com'
+          }
+        }
+      });
+
+      representativeDetails.fields.postcodeLookup.value = null;
+      representativeDetails.fields.postcodeAddress.value = null;
+      values = representativeDetails.values();
+      expect(values).to.eql({
+        representative: {
+          title: 'Title',
+          firstName: 'First name',
+          lastName: 'Last name',
+          organisation: 'Organisation',
+          contactDetails: {
+            addressLine1: 'First line of my address',
+            addressLine2: 'Second line of my address',
+            townCity: 'Town or City',
+            county: 'County',
+            postCode: 'Postcode',
+            postcodeLookup: '',
             postcodeAddress: '',
             phoneNumber: '0800109756',
             emailAddress: 'myemailaddress@sscs.com'

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -4,7 +4,7 @@ const RepresentativeDetails = require('steps/representative/representative-detai
 const paths = require('paths');
 const userAnswer = require('utils/answer');
 const sinon = require('sinon');
-const pcl = require('components/postcodeLookup/controller');
+
 
 const config = require('config');
 
@@ -51,11 +51,11 @@ describe('RepresentativeDetails.js', () => {
     let pclSpy = '';
 
     beforeEach(() => {
-      pclSpy = sinon.spy(pcl, 'controller');
+      pclSpy = sinon.spy(representativeDetails.pcl, 'init');
     });
 
     afterEach(() => {
-      pcl.controller.restore();
+      representativeDetails.pcl.init.restore();
     });
 
     const req = { method: 'GET', body: {}, session: {}, query: {} };
@@ -155,6 +155,13 @@ describe('RepresentativeDetails.js', () => {
 
     it('should contain dynamic fields', () => {
       if (isPostCodeLookupEnabled) {
+        const req = { method: 'GET', body: {}, session: {}, query: {} };
+        const next = sinon.spy();
+        const redirect = sinon.spy();
+        const res = { redirect };
+        representativeDetails.req = req;
+        representativeDetails.handler(req, res, next);
+        fields = representativeDetails.form.fields;
         expect(Object.keys(fields).length).to.equal(4);
         expect(fields).to.have.all.keys(
           'name',

--- a/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
+++ b/test/unit/steps/representative/representative-details/RepresentativeDetails.test.js
@@ -63,6 +63,7 @@ describe('RepresentativeDetails.js', () => {
     const redirect = sinon.spy();
     const res = { redirect };
     it('call pcl controller once', () => {
+      representativeDetails.req = req;
       representativeDetails.handler(req, res, next);
       expect(pclSpy).to.have.been.calledOnce;
     });


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-5710

### Change description ###
- Refactor pages which use the postcodelookup component to return "postcodeLookup and postcodeAddress field values".
- Refactor postcode lookup to not use the session to store address suggestions.
- Refactor postcode lookup to support manual - to auto switch
- Refactor complexity
- Convert postcode lookup into a class for unit testing



**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
