### PR TITLE
SSCS-5725 Donot check postcode if blank

### DIFF
--- a/test/unit/utils/postcodeChecker.test.js
+++ b/test/unit/utils/postcodeChecker.test.js
@@ -138,6 +138,17 @@ describe('PostcodeChecker.js', () => {
         });
     });
 
+    it('do not blank postcodes', () => {
+      return postcodeChecker('')
+        .then(isEnglandOrWalesPostcode => {
+          expect(isEnglandOrWalesPostcode).to.equal(false);
+          expect(getStub).not.to.have.been.called;
+        }).catch(error => {
+          expect.fail(error);
+        });
+    });
+
+
     it('error getting country', () => {
       const expectedError = 'Some error';
 

--- a/utils/postcodeChecker.js
+++ b/utils/postcodeChecker.js
@@ -17,6 +17,11 @@ const postcodeChecker = (postcode, allowUnknownPostcodes = false) => {
   return new Promise((resolve, reject) => {
     const outcode = postcode.trim().replace(inwardPostcode, '').replace(/\s+/, '');
 
+    if (!outcode && !outcode.trim()) {
+      resolve(allowUnknownPostcodes);
+      return;
+    }
+
     request.get(`${postcodeCountryLookupUrl}/${outcode}`)
       .ok(res => res.status < HttpStatus.INTERNAL_SERVER_ERROR)
       .then(resp => {


### PR DESCRIPTION
If the user has not entered a postcode we are still calling the postcode
lookup service. There url ends up being /regionalcentre/ rather than
/regionalcentre/{outcode}. /regionalcentre/ is not mapped to anything
so gets back a 404. Add a check before calling the postcode lookup
service so its not called if we don't have a postcode.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-5725

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
