### PR TITLE
Disable ASE on AAT

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -48,7 +48,7 @@ withPipeline("nodejs", product, component) {
   enableDockerBuild()
   installCharts()
   enableAksStagingDeployment()
-  // disableLegacyDeploymentOnAAT()
+  disableLegacyDeploymentOnAAT()
 
   after("smoketest:preview") {
       stage('Application URLs') {


### PR DESCRIPTION
### JIRA link (if applicable) ###
AB#729


### Change description ###
This means that the ASE will no longer be updated,
The new url is: https://benefit-appeal.aat.platform.hmcts.net/



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
