### PR TITLE
SSCS-7059 Clicking back on appeal-form-download results in internal server error

### DIFF
--- a/steps/appeal-form-download/AppealFormDownload.js
+++ b/steps/appeal-form-download/AppealFormDownload.js
@@ -1,16 +1,28 @@
-const { form, text } = require('@hmcts/one-per-page/forms');
-const { Question } = require('@hmcts/one-per-page');
+const { ExitPoint } = require('@hmcts/one-per-page');
+const { get } = require('lodash');
 const paths = require('paths');
 const urls = require('urls');
 const benefitTypes = require('steps/start/benefit-type/types');
+const preserveSession = require('middleware/preserveSession');
 
-class AppealFormDownload extends Question {
+class AppealFormDownload extends ExitPoint {
   static get path() {
     return paths.appealFormDownload;
   }
 
+  get session() {
+    return this.req.sess;
+  }
+
+  get middleware() {
+    return [
+      preserveSession,
+      ...super.middleware
+    ];
+  }
+
   get benefitType() {
-    return this.fields.benefitType.value;
+    return get(this, 'session.BenefitType.benefitType');
   }
 
   isBenefitInList(list, benefit) {
@@ -18,7 +30,7 @@ class AppealFormDownload extends Question {
   }
 
   get formDownload() {
-    const benefitType = this.fields.benefitType.value;
+    const benefitType = this.benefitType;
     const formDownload = {};
 
     const sscs5 = ['childBenefit', 'childCare', 'taxCredits', 'contractedOut', 'taxFreeChildcare'];
@@ -36,12 +48,6 @@ class AppealFormDownload extends Question {
     }
 
     return formDownload;
-  }
-
-  get form() {
-    return form({
-      benefitType: text.ref(this.journey.steps.BenefitType, 'benefitType')
-    });
   }
 }
 

--- a/test/unit/steps/identity/appeal-form-download/AppealFormDownload.test.js
+++ b/test/unit/steps/identity/appeal-form-download/AppealFormDownload.test.js
@@ -3,19 +3,20 @@ const { expect } = require('test/util/chai');
 const paths = require('paths');
 const urls = require('urls');
 const benefitTypes = require('steps/start/benefit-type/types');
+const preserveSession = require('middleware/preserveSession');
 
 describe('AppealFormDownload.js', () => {
   let appealFormDownload = null;
 
   beforeEach(() => {
     appealFormDownload = new AppealFormDownload({
-      journey: {
-        steps: {}
+      journey: {},
+      sess: {
+        BenefitType: {
+          benefitType: null
+        }
       }
     });
-    appealFormDownload.fields = {
-      benefitType: {}
-    };
   });
 
   describe('get path()', () => {
@@ -26,42 +27,52 @@ describe('AppealFormDownload.js', () => {
 
   describe('get benefitType()', () => {
     it('returns correct wording', () => {
-      appealFormDownload.fields.benefitType.value = 'some benefitType';
+      appealFormDownload.req.sess.BenefitType.benefitType = 'some benefitType';
       expect(appealFormDownload.benefitType).to.equal('some benefitType');
     });
   });
 
   describe('get getFormLink()', () => {
     it('returns SSCS5 form link when Benefit type is Child Benefit Lone Parent', () => {
-      appealFormDownload.fields.benefitType.value = benefitTypes.childBenefit;
+      appealFormDownload.req.sess.BenefitType.benefitType = benefitTypes.childBenefit;
       expect(appealFormDownload.formDownload.link).to.equal(urls.formDownload.sscs5);
     });
 
     it('returns SSCS5 form type when Benefit type is Child Benefit Lone Parent', () => {
-      appealFormDownload.fields.benefitType.value = benefitTypes.childBenefit;
+      appealFormDownload.req.sess.BenefitType.benefitType = benefitTypes.childBenefit;
       expect(appealFormDownload.formDownload.type).to.equal('SSCS5');
     });
 
     it('returns SSCS1 form link when Benefit type is not Child Benefit Lone Parent', () => {
-      appealFormDownload.fields.benefitType.value = benefitTypes.socialFund;
+      appealFormDownload.req.sess.BenefitType.benefitType = benefitTypes.socialFund;
       expect(appealFormDownload.formDownload.link).to.equal(urls.formDownload.sscs1);
     });
 
     it('returns SSCS1 form type when Benefit type is not Child Benefit Lone Parent', () => {
-      appealFormDownload.fields.benefitType.value = benefitTypes.socialFund;
+      appealFormDownload.req.sess.BenefitType.benefitType = benefitTypes.socialFund;
       expect(appealFormDownload.formDownload.type).to.equal('SSCS1');
+    });
+
+    it('returns SSCS3 form link when Benefit type is Compensation Recovery', () => {
+      appealFormDownload.req.sess.BenefitType.benefitType = benefitTypes.compensationRecovery;
+      expect(appealFormDownload.formDownload.link).to.equal(urls.formDownload.sscs3);
+    });
+
+    it('returns SSCS3 form type when Benefit type is Compensation Recovery', () => {
+      appealFormDownload.req.sess.BenefitType.benefitType = benefitTypes.compensationRecovery;
+      expect(appealFormDownload.formDownload.type).to.equal('SSCS3');
     });
   });
 
-  describe('get form()', () => {
-    it('should contain 1 fields', () => {
-      expect(Object.keys(appealFormDownload.form.fields).length).to.equal(1);
+  describe('get session()', () => {
+    it('returns the session from the request', () => {
+      expect(appealFormDownload.session).to.equal(appealFormDownload.req.sess);
     });
+  });
 
-    it('should contain a textField reference called \'benefitType\'', () => {
-      const textField = appealFormDownload.form.fields.benefitType;
-      expect(textField.constructor.name).to.eq('FieldDescriptor');
-      expect(textField.validations).to.be.empty;
+  describe('get middleware()', () => {
+    it('returns path /confirmation', () => {
+      expect(appealFormDownload.middleware[0]).to.equal(preserveSession);
     });
   });
 });


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-7059

### Change description ###
Fixing back button on appeal form download page

* change `AppealFormDownload` step to extend `ExitPoint`
* ensure session is preserved to be able to obtain the chosen benefit type from the session to show on the page
* the form download links remain the same as before the fix

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
