### PR TITLE
SSCS-7550: Remove Newcastle from allowedRpcs

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -45,7 +45,6 @@ withPipeline("nodejs", product, component) {
     }
   }
 
-  installCharts()
   enableAksStagingDeployment()
   disableLegacyDeployment()
 

--- a/config/default.json
+++ b/config/default.json
@@ -55,7 +55,7 @@
   "postcodeChecker": {
     "endpoint": "/regionalcentre",
     "enabled": true,
-    "allowedRpcs": "birmingham,liverpool,sutton,leeds,newcastle,cardiff,glasgow,bradford"
+    "allowedRpcs": "birmingham,liverpool,sutton,leeds,cardiff,glasgow,bradford"
   },
   "postcodeLookup": {
     "url": "https://api.ordnancesurvey.co.uk/places/v1",


### PR DESCRIPTION
### SSCS-7550 - Reference data – Update Airlookup – Newcastle RPC to Leeds RPC