### PR TITLE
SSCS-8328 restart on liveliness failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,4 +137,3 @@ Execute an interactive bash shell on the container
     docker exec -it <container id> sh
 
 
-// dummy commmit

--- a/README.md
+++ b/README.md
@@ -137,3 +137,4 @@ Execute an interactive bash shell on the container
     docker exec -it <container id> sh
 
 
+// dummy commmit

--- a/charts/sscs-tribunals-frontend/Chart.yaml
+++ b/charts/sscs-tribunals-frontend/Chart.yaml
@@ -3,7 +3,7 @@ name: sscs-tribunals-frontend
 home: https://github.com/hmcts/sscs-submit-your-appeal
 apiVersion: v2
 appVersion: "1.0"
-version: 0.2.11
+version: 0.2.12
 maintainers:
   - name: HMCTS SSCS Team
 dependencies:

--- a/charts/sscs-tribunals-frontend/Chart.yaml
+++ b/charts/sscs-tribunals-frontend/Chart.yaml
@@ -3,7 +3,7 @@ name: sscs-tribunals-frontend
 home: https://github.com/hmcts/sscs-submit-your-appeal
 apiVersion: v2
 appVersion: "1.0"
-version: 0.2.10
+version: 0.2.11
 maintainers:
   - name: HMCTS SSCS Team
 dependencies:

--- a/charts/sscs-tribunals-frontend/values.preview.template.yaml
+++ b/charts/sscs-tribunals-frontend/values.preview.template.yaml
@@ -1,7 +1,6 @@
 nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
-  livenessPath: /health/readiness
   environment:
     REDIS_URL: redis://${SERVICE_NAME}-redis-master
     APPINSIGHTS_ROLE_NAME: ${SERVICE_NAME}

--- a/charts/sscs-tribunals-frontend/values.preview.template.yaml
+++ b/charts/sscs-tribunals-frontend/values.preview.template.yaml
@@ -1,11 +1,11 @@
 nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
+  livenessPath: /health/readiness
   environment:
     REDIS_URL: redis://${SERVICE_NAME}-redis-master
     APPINSIGHTS_ROLE_NAME: ${SERVICE_NAME}
     PCQ_URL: "https://pcq.aat.platform.hmcts.net"
-
   keyVaults:
     sscs:
       secrets:

--- a/charts/sscs-tribunals-frontend/values.yaml
+++ b/charts/sscs-tribunals-frontend/values.yaml
@@ -2,6 +2,7 @@ nodejs:
   image: 'hmctspublic.azurecr.io/sscs/tribunals-frontend:latest'
   applicationPort: 3000
   aadIdentityName: sscs
+  livenessPath: /health/readiness
   environment:
     NODE_ENV: "production"
     TRIBUNALS_CASE_API_URL: http://sscs-tribunals-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-8238


### Change description ###
HMCTS Health Checks pakage hard codes /health/liveness response to 200 Status: Up. Therefore will never be restarted by Kubernetes, even when Redis is unavailable and readiness health check fails. Solution is to use the readiness end point also for the liveness check. You can witness Kubernetes restart the SYA pods following 3 readiness fails.


