### PR TITLE
SSCS-8340 Redis Connection Retry Strategy

### DIFF
--- a/appConfigurations.js
+++ b/appConfigurations.js
@@ -152,7 +152,18 @@ const configureJourney = (app, commonContent) => {
     session: {
       redis: {
         url: config.redis.url,
-        connect_timeout: 15000
+        retry_strategy: function(options) {
+          const { error, total_retry_time, attempt } = options;
+          if (error) {
+            console.log(`Redis connection failed with ${error.code}`);
+          }
+          console.log(`Redis retrying connection attempt ${attempt} total retry time ${total_retry_time} ms`);
+          // reconnect after
+          const minRetryFactor = 500;
+          const retryTime = attempt * minRetryFactor;
+          const maxRetryWait = 3000;
+          return Math.min(retryTime, maxRetryWait);
+        }
       },
       cookie: {
         secure: config.get('node.protocol') === 'https'

--- a/appConfigurations.js
+++ b/appConfigurations.js
@@ -146,13 +146,14 @@ const configureHelmet = app => {
   }));
 };
 
+/*eslint-disable */
 const configureJourney = (app, commonContent) => {
   journey(app, {
     steps,
     session: {
       redis: {
         url: config.redis.url,
-        retry_strategy: function(options) {
+        retry_strategy(options) {
           const { error, total_retry_time, attempt } = options;
           if (error) {
             console.log(`Redis connection failed with ${error.code}`);
@@ -190,6 +191,7 @@ const configureJourney = (app, commonContent) => {
     useCsrfToken: false
   });
 };
+/* eslint-enable */
 
 const configureMiddleWares = (app, express) => {
   app.use('/assets', express.static(path.resolve('dist')));

--- a/services/healthcheck.js
+++ b/services/healthcheck.js
@@ -9,12 +9,12 @@ const { OK } = require('http-status-codes');
 const logger = require('logger');
 
 
-const client = ioRedis.createClient(
+const ioRedisClient = ioRedis.createClient(
   config.redis.url,
   { enableOfflineQueue: false }
 );
 
-client.on('error', error => {
+ioRedisClient.on('error', error => {
   logger.trace(`Health check failed on redis: ${error}`, 'health_check_error');
 });
 
@@ -34,7 +34,7 @@ const healthOptions = message => {
 const setup = app => {
   healthcheck.addTo(app, {
     checks: {
-      redis: healthcheck.raw(() => client.ping().then(_ => healthcheck.status(_ === 'PONG'))
+      redis: healthcheck.raw(() => ioRedisClient.ping().then(_ => healthcheck.status(_ === 'PONG'))
         .catch(error => {
           logger.trace(`Health check failed on redis: ${error}`, 'health_check_error');
           return outputs.down(error);
@@ -44,7 +44,7 @@ const setup = app => {
       )
     },
     readinessChecks: {
-      redis: healthcheck.raw(() => client.ping().then(_ => healthcheck.status(_ === 'PONG'))
+      redis: healthcheck.raw(() => ioRedisClient.ping().then(_ => healthcheck.status(_ === 'PONG'))
         .catch(error => {
           logger.trace(`Readiness check failed on redis: ${error}`, 'Readiness_check_error');
           return outputs.down(error);


### PR DESCRIPTION
The existing `connect_timeout` parameter value passed to the redis client was causing the client to stop retrying to connect to redis after 15 seconds, hence the hanging.

This has been replaced with a retry strategy that will continue to reconnect to redis indefinitely and log the errors and attempts. 

Health check remains as is for now. We may wish to remove the redis check from it in the future


**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
