### PR TITLE
SSCS-8609:Multi draft page displayed as entry page for user stored session

### DIFF
--- a/steps/entry/Entry.js
+++ b/steps/entry/Entry.js
@@ -1,6 +1,9 @@
 const { goTo } = require('@hmcts/one-per-page');
 const { RestoreFromDraftStore } = require('middleware/draftAppealStoreMiddleware');
 const paths = require('paths');
+const config = require('config');
+
+const multipleDraftsEnabled = config.get('features.multipleDraftsEnabled.enabled') === 'true';
 
 class Entry extends RestoreFromDraftStore {
   static get path() {
@@ -9,7 +12,11 @@ class Entry extends RestoreFromDraftStore {
 
   handler(req, res, next) {
     if (req.session.isUserSessionRestored) {
-      res.redirect(paths.checkYourAppeal);
+      if (multipleDraftsEnabled) {
+        res.redirect(paths.drafts);
+      } else {
+        res.redirect(paths.checkYourAppeal);
+      }
     } else {
       super.handler(req, res, next);
     }

--- a/test/unit/steps/entry/Entry.test.js
+++ b/test/unit/steps/entry/Entry.test.js
@@ -60,6 +60,22 @@ describe('Entry.js', () => {
     });
   });
 
+  describe('When method user data is restored for multi drafts', () => {
+    const req = { session: { isUserSessionRestored: true } };
+    const redirect = sinon.spy();
+    const res = {
+      redirect,
+      sendStatus: sinon.spy()
+    };
+    it('should not call `super.handler()`', () => {
+      // eslint-disable-next-line no-process-env
+      process.env.MULTIPLE_DRAFTS_ENABLED = 'true';
+      entry.handler(req, res);
+      expect(redirect.called).to.eql(true);
+      expect(mockHandler.calledOnce).to.eql(false);
+    });
+  });
+
   describe('When method user data is not restored', () => {
     const req = { session: { isUserSessionRestored: false } };
     const redirect = sinon.spy();
@@ -67,7 +83,7 @@ describe('Entry.js', () => {
       redirect,
       sendStatus: sinon.spy()
     };
-    it('should not call `super.handler()`', () => {
+    it('should call `super.handler()`', () => {
       entry.handler(req, res);
       expect(redirect.called).to.eql(false);
       expect(mockHandler.calledOnce).to.eql(true);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-8609

### Change description ###
When multiple draft is enabled and user session is stored, click on Appeal benefit decision takes to drafts appeal page.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```