### PR TITLE
SSCS-9034 - Tribunals – Migrate OS places and names API

### DIFF
--- a/components/postcodeLookup/controller.js
+++ b/components/postcodeLookup/controller.js
@@ -159,7 +159,7 @@ class Controller {
     const postCode = page.fields[fieldMap.postcodeLookup].value;
     const options = {
       json: true,
-      uri: `${this.apiUrl}/addresses/postcode?postcode=${postCode}&key=${this.token}`,
+      uri: `${this.apiUrl}/postcode?&key=${this.token}&postcode=${postCode}&lr=EN`,
       method: 'GET'
     };
 

--- a/config/default.json
+++ b/config/default.json
@@ -87,7 +87,7 @@
     "allowedRpcs": "birmingham,liverpool,sutton,leeds,cardiff,glasgow,bradford"
   },
   "postcodeLookup": {
-    "url": "https://api.ordnancesurvey.co.uk/places/v1",
+    "url": "https://api.os.uk/search/places/v1",
     "token": "",
     "enabled": "true"
   },

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "minimist": "^1.2.5",
     "electron": "^9.4.0",
     "axios": "^0.21.1",
-    "elliptic": "^6.5.4"
+    "elliptic": "^6.5.4",
+    "ssri": "6.0.2"
   }
 }

--- a/test/unit/components/postcodeLookup/controller.test.js
+++ b/test/unit/components/postcodeLookup/controller.test.js
@@ -39,7 +39,7 @@ describe('Components/controller.js', () => {
       .defaultReplyHeaders({
         'Content-Type': 'application/json'
       })
-      .get(`/addresses/postcode?postcode=n29ed&key=${token}`)
+      .get(`/postcode?&key=${token}&postcode=n29ed&lr=EN`)
       .reply(200, { results: [ 'address:1', 'address:2'] });
   });
 


### PR DESCRIPTION
SSCS-9034 - Tribunals – Migrate OS places and names API

This PR changes the URL from `https://api.ordnancesurvey.co.uk/places/v1/addresses/postcode` to `https://api.os.uk/search/places/v1/postcode`

The azure secret **postcode-lookup-token** will need to change.