### PR TITLE
SSCS-9113 - Remove FT_ALLOW_UC_HEARING_OPTIONS flag

### DIFF
--- a/appConfigurations.js
+++ b/appConfigurations.js
@@ -73,8 +73,7 @@ const configureNunjucks = (app, commonContent) => {
       urls,
       featureToggles: {
         welsh: () => process.env.FT_WELSH || config.features.welsh.enabled,
-        antennaWebChat: () => process.env.FT_ANTENNA_WEBCHAT || config.features.antennaWebChat.enabled,
-        allowUCHearingOption: () => process.env.FT_ALLOW_UC_HEARING_OPTIONS || config.features.allowUCHearingOption.enabled
+        antennaWebChat: () => process.env.FT_ANTENNA_WEBCHAT || config.features.antennaWebChat.enabled
       }
     }
   });

--- a/charts/sscs-tribunals-frontend/Chart.yaml
+++ b/charts/sscs-tribunals-frontend/Chart.yaml
@@ -3,7 +3,7 @@ name: sscs-tribunals-frontend
 home: https://github.com/hmcts/sscs-submit-your-appeal
 apiVersion: v2
 appVersion: "1.0"
-version: 0.2.18
+version: 0.2.19
 maintainers:
   - name: HMCTS SSCS Team
 dependencies:

--- a/charts/sscs-tribunals-frontend/values.aat.template.yaml
+++ b/charts/sscs-tribunals-frontend/values.aat.template.yaml
@@ -4,7 +4,6 @@ nodejs:
   environment:
     FT_ANTENNA_WEBCHAT: false
     PCQ_URL: "https://pcq.aat.platform.hmcts.net"
-    FT_ALLOW_UC_HEARING_OPTIONS: true
     FT_WELSH: true
     PCQ_ENABLED: true
     MULTIPLE_DRAFTS_ENABLED: true

--- a/charts/sscs-tribunals-frontend/values.preview.template.yaml
+++ b/charts/sscs-tribunals-frontend/values.preview.template.yaml
@@ -6,7 +6,6 @@ nodejs:
     APPINSIGHTS_ROLE_NAME: ${SERVICE_NAME}
     PCQ_URL: "https://pcq.aat.platform.hmcts.net"
     FT_ANTENNA_WEBCHAT: false
-    FT_ALLOW_UC_HEARING_OPTIONS: true
     FT_WELSH: true
     PCQ_ENABLED: true
     MULTIPLE_DRAFTS_ENABLED: true

--- a/charts/sscs-tribunals-frontend/values.yaml
+++ b/charts/sscs-tribunals-frontend/values.yaml
@@ -28,7 +28,6 @@ nodejs:
     POSTCODE_CHECKER_ALLOWED_RPCS: "birmingham,liverpool,sutton,leeds,newcastle,cardiff,glasgow,bradford"
     UV_THREADPOOL_SIZE: 64
     FT_ANTENNA_WEBCHAT: false
-    FT_ALLOW_UC_HEARING_OPTIONS: false
     FT_WELSH: true
     ALLOW_DLA_ENABLED: true
 

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -72,9 +72,6 @@
     "antennaWebChat": {
       "enabled": "FT_ANTENNA_WEBCHAT"
     },
-    "allowUCHearingOption": {
-      "enabled": "FT_ALLOW_UC_HEARING_OPTIONS"
-    },
     "multipleDraftsEnabled": {
       "enabled": "MULTIPLE_DRAFTS_ENABLED"
     }

--- a/config/default.json
+++ b/config/default.json
@@ -77,9 +77,6 @@
     "antennaWebChat": {
       "enabled": "false"
     },
-    "allowUCHearingOption": {
-      "enabled": "false"
-    },
     "multipleDraftsEnabled": {
       "enabled": "false"
     }

--- a/steps/hearing/the-hearing/TheHearing.js
+++ b/steps/hearing/the-hearing/TheHearing.js
@@ -9,7 +9,6 @@ const paths = require('paths');
 const userAnswer = require('utils/answer');
 const sections = require('steps/check-your-appeal/sections');
 const i18next = require('i18next');
-const config = require('config');
 
 class TheHearing extends SaveToDraftStore {
   static get path() {
@@ -53,9 +52,8 @@ class TheHearing extends SaveToDraftStore {
 
   next() {
     const isAttendingHearing = () => this.fields.attendHearing.value === userAnswer.YES;
-    const allowUCHearingOption = () => (process.env.FT_ALLOW_UC_HEARING_OPTIONS === 'true' || config.features.allowUCHearingOption.enabled === 'true');
     return branch(
-      goTo(this.journey.steps.HearingOptions).if(isAttendingHearing() && allowUCHearingOption()),
+      goTo(this.journey.steps.HearingOptions).if(isAttendingHearing()),
       goTo(this.journey.steps.HearingSupport).if(isAttendingHearing()),
       redirectTo(this.journey.steps.NotAttendingHearing)
     );

--- a/test/unit/steps/hearing/options/HearingOptions.test.js
+++ b/test/unit/steps/hearing/options/HearingOptions.test.js
@@ -1,7 +1,6 @@
 const HearingOptions = require('steps/hearing/options/HearingOptions');
 const { expect } = require('test/util/chai');
 const paths = require('paths');
-const config = require('config');
 const {
   emptyTelephoneValidation,
   invalidTelephoneValidation,
@@ -13,8 +12,6 @@ const {
 
 describe('HearingOptions.js', () => {
   let hearingOptions = null;
-  const testConfig = JSON.parse(JSON.stringify(config));
-  testConfig.features.allowUCHearingOption.enabled = 'true';
 
   beforeEach(() => {
     hearingOptions = new HearingOptions({

--- a/test/unit/steps/hearing/the-hearing/TheHearing.test.js
+++ b/test/unit/steps/hearing/the-hearing/TheHearing.test.js
@@ -96,18 +96,9 @@ describe('TheHearing.js', () => {
   });
 
   describe('next()', () => {
-    it('returns the next step path /hearing-options when attendHearing value is Yes and allowUCHearingOption is true', () => {
-      // eslint-disable-next-line no-process-env
-      process.env.FT_ALLOW_UC_HEARING_OPTIONS = 'true';
+    it('returns the next step path /hearing-options when attendHearing value is Yes', () => {
       theHearing.fields.attendHearing.value = 'yes';
       expect(theHearing.next().step).to.eq(paths.hearing.hearingOptions);
-    });
-
-    it('returns the next step path /hearing-support when attendHearing value is Yes and allowUCHearingOption is false', () => {
-      // eslint-disable-next-line no-process-env
-      process.env.FT_ALLOW_UC_HEARING_OPTIONS = 'false';
-      theHearing.fields.attendHearing.value = 'yes';
-      expect(theHearing.next().step).to.eq(paths.hearing.hearingSupport);
     });
 
     it('returns the next step path /not-attending-hearing when attendHearing value is No', () => {


### PR DESCRIPTION
SSCS-9113 - Remove FT_ALLOW_UC_HEARING_OPTIONS flag

The universal credit changes have been live since around Nov 2020 and therefore it’ll be best if this feature flag was removed and any tests that now need to be amended (nightly and pipeline) are done so.

The result of removing the flag FT_ALLOW_UC_HEARING_OPTIONS, should be as if it = true.
