### PR TITLE
SSCS-9025 Automation Tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "ecmaVersion": 2017
   },
   "rules": {
+	"linebreak-style": ["warn", "unix"],
     "no-process-env": "off",
     "multiline-ternary": ["error", "always-multiline"],
     "operator-linebreak": ["error", "after"],

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -5,6 +5,7 @@ properties([
         parameters([
                 string(name: 'URL_TO_TEST', defaultValue: 'https://benefit-appeal.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
                 string(name: 'IDAM_URL', defaultValue: 'https://idam-api.aat.platform.hmcts.net', description: 'The IDAM URL where test accounts get created'),
+                string(name: 'TRIBUNALS_CASE_API_URL', defaultValue: 'http://sscs-tribunals-api-aat.service.core-compute-aat.internal', description: 'The Tribunal api to view the cases'),
                 string(name: 'SecurityRules',
                  defaultValue: 'http://raw.githubusercontent.com/hmcts/security-test-rules/master/conf/security-rules.conf',
                  description: 'The URL you want to run these tests against'),
@@ -35,6 +36,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withNightlyPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
     env.TEST_URL = params.URL_TO_TEST
+    env.TRIBUNALS_CASE_API_URL = params.TRIBUNALS_CASE_API_URL
 
     before('DependencyCheckNightly') {sh 'yarn test:audit'}
     enableCrossBrowserTest(60)

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -10,6 +10,7 @@
     "ecmaVersion": 2017
   },
   "rules": {
+	"linebreak-style": ["warn", "unix"],
     "object-curly-newline": ["error", {
       "consistent": true
     }],

--- a/test/e2e/codecept.conf.js
+++ b/test/e2e/codecept.conf.js
@@ -49,6 +49,8 @@ exports.config = {
     MyHelper: {
       require: './helpers/helper.js',
       url: config.get('e2e.frontendUrl')
+    },
+    REST: {
     }
   },
   include: {

--- a/test/e2e/journeys/draftSubmitVerify.cy.test.js
+++ b/test/e2e/journeys/draftSubmitVerify.cy.test.js
@@ -1,0 +1,53 @@
+const language = 'cy';
+const commonContent = require('commonContent')[language];
+const moment = require('moment');
+const paths = require('paths');
+const testData = require(`test/e2e/data.${language}`);
+const testUser = require('../../util/IdamUser');
+const assert = require('assert');
+
+const appellant = testData.appellant;
+let userEmail = '';
+
+Feature(`${language.toUpperCase()} - Verifying data when drafts are submitted to CCD`);
+
+Before(I => {
+  I.createTheSession(language);
+  I.seeCurrentUrlEquals(paths.start.benefitType);
+  userEmail = testUser.createUser();
+});
+
+After(I => {
+  I.endTheSession();
+  testUser.deleteUser(userEmail);
+});
+
+Scenario(`${language.toUpperCase()} - Sign in and submit draft appeal and verify the submitted CCD  @fullFunctional`,
+  async I => {
+    await moment().locale(language);
+    await I.enterDetailsFromStartToDraft(commonContent, language, userEmail);
+    I.navigateToDrafts(language);
+    const ccdCaseID = await I.editDraftAppeal(language);
+    I.continueIncompleteAppeal(language);
+    I.continueFromIndependance(commonContent);
+    I.selectHaveYouGotAMRNAndContinueAfterSignIn(commonContent, '#haveAMRN-no');
+    I.selectHaveYouContactedDWPAndContinueAfterSignIn(commonContent, '#haveContactedDWP-yes');
+    I.enterReasonForNoMRNAndContinueAfterSignIn(commonContent, testData.mrn.reasonForNoMRN);
+    I.continueFromStillCanAppeal(language);
+    I.selectAreYouAnAppointeeAndContinueAfterSignIn(commonContent, '#isAppointee-no');
+    I.enterAppellantNameAndContinueAfterSignIn(commonContent, appellant.title, appellant.firstName, appellant.lastName);
+    I.enterAppellantDOBAndContinueAfterSignIn(commonContent, appellant.dob.day, appellant.dob.month, appellant.dob.year);
+    I.enterAppellantNINOAndContinueAfterSignIn(commonContent, appellant.nino);
+    I.enterAppellantContactDetailsAndContinueAfterSignIn(commonContent, language);
+    I.checkOptionAndContinueAfterSignIn(commonContent, '#doYouWantTextMsgReminders-no');
+    I.checkOptionAndContinueAfterSignIn(commonContent, '#hasRepresentative-no');
+    I.addReasonForAppealingUsingTheOnePageFormAfterSignIn(commonContent, testData.reasonsForAppealing.reasons[0]);
+    I.enterAnythingElseAfterSignIn(commonContent, testData.reasonsForAppealing.otherReasons);
+    I.selectAreYouProvidingEvidenceAfterSignIn(commonContent, '#evidenceProvide-no');
+    I.enterDoYouWantToAttendTheHearingAfterSignIn(commonContent, '#attendHearing-no');
+    I.continueFromnotAttendingHearingAfterSignIn(commonContent);
+    I.checkYourAppealToConfirmationPage(language, testData.signAndSubmit.signer);
+    I.appealSubmitConfirmation(language);
+    const ccdCaseData = await I.getCaseData(commonContent, ccdCaseID);
+    assert.equal(ccdCaseData[0].appeal_details.state, 'incompleteApplication');
+  }).retry(1);

--- a/test/e2e/journeys/draftSubmitVerify.cy.test.js
+++ b/test/e2e/journeys/draftSubmitVerify.cy.test.js
@@ -48,6 +48,6 @@ Scenario(`${language.toUpperCase()} - Sign in and submit draft appeal and verify
     I.continueFromnotAttendingHearingAfterSignIn(commonContent);
     I.checkYourAppealToConfirmationPage(language, testData.signAndSubmit.signer);
     I.appealSubmitConfirmation(language);
-    const ccdCaseData = await I.getCaseData(commonContent, ccdCaseID);
+    const ccdCaseData = await I.getCaseData(I, ccdCaseID);
     assert.equal(ccdCaseData[0].appeal_details.state, 'incompleteApplication');
   }).retry(1);

--- a/test/e2e/journeys/draftSubmitVerify.cy.test.js
+++ b/test/e2e/journeys/draftSubmitVerify.cy.test.js
@@ -38,7 +38,7 @@ Scenario(`${language.toUpperCase()} - Sign in and submit draft appeal and verify
     I.enterAppellantNameAndContinueAfterSignIn(commonContent, appellant.title, appellant.firstName, appellant.lastName);
     I.enterAppellantDOBAndContinueAfterSignIn(commonContent, appellant.dob.day, appellant.dob.month, appellant.dob.year);
     I.enterAppellantNINOAndContinueAfterSignIn(commonContent, appellant.nino);
-    I.enterAppellantContactDetailsAndContinueAfterSignIn(commonContent, language);
+    I.enterAppellantContactDetailsWithMobileAndContinueAfterSignIn(commonContent, language);
     I.checkOptionAndContinueAfterSignIn(commonContent, '#doYouWantTextMsgReminders-no');
     I.checkOptionAndContinueAfterSignIn(commonContent, '#hasRepresentative-no');
     I.addReasonForAppealingUsingTheOnePageFormAfterSignIn(commonContent, testData.reasonsForAppealing.reasons[0]);
@@ -50,4 +50,4 @@ Scenario(`${language.toUpperCase()} - Sign in and submit draft appeal and verify
     I.appealSubmitConfirmation(language);
     const ccdCaseData = await I.getCaseData(I, ccdCaseID);
     assert.equal(ccdCaseData[0].appeal_details.state, 'incompleteApplication');
-  }).retry(1);
+  }).retry(20);

--- a/test/e2e/journeys/draftSubmitVerify.en.test.js
+++ b/test/e2e/journeys/draftSubmitVerify.en.test.js
@@ -48,6 +48,6 @@ Scenario(`${language.toUpperCase()} - Sign in and submit draft appeal and verify
     I.continueFromnotAttendingHearingAfterSignIn(commonContent);
     I.checkYourAppealToConfirmationPage(language, testData.signAndSubmit.signer);
     I.appealSubmitConfirmation(language);
-    const ccdCaseData = await I.getCaseData(commonContent, ccdCaseID);
+    const ccdCaseData = await I.getCaseData(I, ccdCaseID);
     assert.equal(ccdCaseData[0].appeal_details.state, 'incompleteApplication');
   }).retry(1);

--- a/test/e2e/journeys/draftSubmitVerify.en.test.js
+++ b/test/e2e/journeys/draftSubmitVerify.en.test.js
@@ -38,7 +38,7 @@ Scenario(`${language.toUpperCase()} - Sign in and submit draft appeal and verify
     I.enterAppellantNameAndContinueAfterSignIn(commonContent, appellant.title, appellant.firstName, appellant.lastName);
     I.enterAppellantDOBAndContinueAfterSignIn(commonContent, appellant.dob.day, appellant.dob.month, appellant.dob.year);
     I.enterAppellantNINOAndContinueAfterSignIn(commonContent, appellant.nino);
-    I.enterAppellantContactDetailsAndContinueAfterSignIn(commonContent, language);
+    I.enterAppellantContactDetailsWithMobileAndContinueAfterSignIn(commonContent, language);
     I.checkOptionAndContinueAfterSignIn(commonContent, '#doYouWantTextMsgReminders-no');
     I.checkOptionAndContinueAfterSignIn(commonContent, '#hasRepresentative-no');
     I.addReasonForAppealingUsingTheOnePageFormAfterSignIn(commonContent, testData.reasonsForAppealing.reasons[0]);
@@ -50,4 +50,4 @@ Scenario(`${language.toUpperCase()} - Sign in and submit draft appeal and verify
     I.appealSubmitConfirmation(language);
     const ccdCaseData = await I.getCaseData(I, ccdCaseID);
     assert.equal(ccdCaseData[0].appeal_details.state, 'incompleteApplication');
-  }).retry(1);
+  }).retry(20);

--- a/test/e2e/journeys/draftSubmitVerify.en.test.js
+++ b/test/e2e/journeys/draftSubmitVerify.en.test.js
@@ -1,0 +1,53 @@
+const language = 'en';
+const commonContent = require('commonContent')[language];
+const moment = require('moment');
+const paths = require('paths');
+const testData = require(`test/e2e/data.${language}`);
+const testUser = require('../../util/IdamUser');
+const assert = require('assert');
+
+const appellant = testData.appellant;
+let userEmail = '';
+
+Feature(`${language.toUpperCase()} - Verifying data when drafts are submitted to CCD`);
+
+Before(I => {
+  I.createTheSession(language);
+  I.seeCurrentUrlEquals(paths.start.benefitType);
+  userEmail = testUser.createUser();
+});
+
+After(I => {
+  I.endTheSession();
+  testUser.deleteUser(userEmail);
+});
+
+Scenario(`${language.toUpperCase()} - Sign in and submit draft appeal and verify the submitted CCD  @fullFunctional`,
+  async I => {
+    await moment().locale(language);
+    await I.enterDetailsFromStartToDraft(commonContent, language, userEmail);
+    I.navigateToDrafts(language);
+    const ccdCaseID = await I.editDraftAppeal(language);
+    I.continueIncompleteAppeal(language);
+    I.continueFromIndependance(commonContent);
+    I.selectHaveYouGotAMRNAndContinueAfterSignIn(commonContent, '#haveAMRN-no');
+    I.selectHaveYouContactedDWPAndContinueAfterSignIn(commonContent, '#haveContactedDWP-yes');
+    I.enterReasonForNoMRNAndContinueAfterSignIn(commonContent, testData.mrn.reasonForNoMRN);
+    I.continueFromStillCanAppeal(language);
+    I.selectAreYouAnAppointeeAndContinueAfterSignIn(commonContent, '#isAppointee-no');
+    I.enterAppellantNameAndContinueAfterSignIn(commonContent, appellant.title, appellant.firstName, appellant.lastName);
+    I.enterAppellantDOBAndContinueAfterSignIn(commonContent, appellant.dob.day, appellant.dob.month, appellant.dob.year);
+    I.enterAppellantNINOAndContinueAfterSignIn(commonContent, appellant.nino);
+    I.enterAppellantContactDetailsAndContinueAfterSignIn(commonContent, language);
+    I.checkOptionAndContinueAfterSignIn(commonContent, '#doYouWantTextMsgReminders-no');
+    I.checkOptionAndContinueAfterSignIn(commonContent, '#hasRepresentative-no');
+    I.addReasonForAppealingUsingTheOnePageFormAfterSignIn(commonContent, testData.reasonsForAppealing.reasons[0]);
+    I.enterAnythingElseAfterSignIn(commonContent, testData.reasonsForAppealing.otherReasons);
+    I.selectAreYouProvidingEvidenceAfterSignIn(commonContent, '#evidenceProvide-no');
+    I.enterDoYouWantToAttendTheHearingAfterSignIn(commonContent, '#attendHearing-no');
+    I.continueFromnotAttendingHearingAfterSignIn(commonContent);
+    I.checkYourAppealToConfirmationPage(language, testData.signAndSubmit.signer);
+    I.appealSubmitConfirmation(language);
+    const ccdCaseData = await I.getCaseData(commonContent, ccdCaseID);
+    assert.equal(ccdCaseData[0].appeal_details.state, 'incompleteApplication');
+  }).retry(1);

--- a/test/e2e/journeys/mrnLate.cy.test.js
+++ b/test/e2e/journeys/mrnLate.cy.test.js
@@ -27,7 +27,7 @@ After(I => {
 });
 
 [oneMonthAndOneDayLate, thirteenMonthsAndOneDayLate].forEach(obj => {
-  Scenario(`${language.toUpperCase()} - Appellant has a MRN that is over ${obj.label}`, I => {
+  Scenario(`${language.toUpperCase()} - Appellant has a MRN that is over ${obj.label} @fullFunctional`, I => {
     I.wait(2);
     I.enterBenefitTypeAndContinue(commonContent, testData.benefitType.code);
     // I.chooseLanguagePreference(commonContent, testData.languagePreferenceWelsh);

--- a/test/e2e/journeys/mrnLate.en.test.js
+++ b/test/e2e/journeys/mrnLate.en.test.js
@@ -27,7 +27,7 @@ After(I => {
 });
 
 [oneMonthAndOneDayLate, thirteenMonthsAndOneDayLate].forEach(obj => {
-  Scenario(`${language.toUpperCase()} - Appellant has a MRN that is over ${obj.label}`, I => {
+  Scenario(`${language.toUpperCase()} - Appellant has a MRN that is over ${obj.label} @fullFunctional`, I => {
     I.wait(2);
     I.enterBenefitTypeAndContinue(commonContent, testData.benefitType.code);
     // I.chooseLanguagePreference(commonContent, testData.languagePreferenceWelsh);

--- a/test/e2e/journeys/noMRN.cy.test.js
+++ b/test/e2e/journeys/noMRN.cy.test.js
@@ -23,7 +23,7 @@ After(I => {
   I.endTheSession();
 });
 
-Scenario(`${language.toUpperCase()} - Appellant has contacted DWP`, async I => {
+Scenario(`${language.toUpperCase()} - Appellant has contacted DWP @fullFunctional`, async I => {
   const randomWeekDay = DateUtils.getDateInMilliseconds(
     DateUtils.getRandomWeekDayFromDate(moment().utc().startOf('day').add(5, 'weeks'))
   );
@@ -49,7 +49,7 @@ Scenario(`${language.toUpperCase()} - Appellant has contacted DWP`, async I => {
   I.confirmDetailsArePresent(language, hasMRN);
 }).retry(1);
 
-Scenario(`${language.toUpperCase()} - Appellant has not contacted DWP and exits the service`, I => {
+Scenario(`${language.toUpperCase()} - Appellant has not contacted DWP and exits the service @fullFunctional`, I => {
   I.enterBenefitTypeAndContinue(commonContent, testData.benefitType.code);
   // I.chooseLanguagePreference(commonContent, testData.languagePreferenceWelsh);
   I.enterPostcodeAndContinue(commonContent, appellant.contactDetails.postCode);

--- a/test/e2e/journeys/noMRN.en.test.js
+++ b/test/e2e/journeys/noMRN.en.test.js
@@ -23,7 +23,7 @@ After(I => {
   I.endTheSession();
 });
 
-Scenario(`${language.toUpperCase()} - Appellant has contacted DWP`, async I => {
+Scenario(`${language.toUpperCase()} - Appellant has contacted DWP @fullFunctional`, async I => {
   const randomWeekDay = DateUtils.getDateInMilliseconds(
     DateUtils.getRandomWeekDayFromDate(moment().utc().startOf('day').add(5, 'weeks'))
   );
@@ -49,7 +49,7 @@ Scenario(`${language.toUpperCase()} - Appellant has contacted DWP`, async I => {
   I.confirmDetailsArePresent(language, hasMRN);
 }).retry(1);
 
-Scenario(`${language.toUpperCase()} - Appellant has not contacted DWP and exits the service`, I => {
+Scenario(`${language.toUpperCase()} - Appellant has not contacted DWP and exits the service @fullFunctional`, I => {
   I.enterBenefitTypeAndContinue(commonContent, testData.benefitType.code);
   // I.chooseLanguagePreference(commonContent, testData.languagePreferenceWelsh);
   I.enterPostcodeAndContinue(commonContent, appellant.contactDetails.postCode);

--- a/test/e2e/page-objects/compliance/haveContactedDWP.js
+++ b/test/e2e/page-objects/compliance/haveContactedDWP.js
@@ -5,4 +5,11 @@ function selectHaveYouContactedDWPAndContinue(commonContent, option) {
   I.click(commonContent.continue);
 }
 
-module.exports = { selectHaveYouContactedDWPAndContinue };
+function selectHaveYouContactedDWPAndContinueAfterSignIn(commonContent, option) {
+  const I = this;
+
+  I.checkOption(option);
+  I.click(commonContent.saveAndContinue);
+}
+
+module.exports = { selectHaveYouContactedDWPAndContinue, selectHaveYouContactedDWPAndContinueAfterSignIn };

--- a/test/e2e/page-objects/compliance/noMRN.js
+++ b/test/e2e/page-objects/compliance/noMRN.js
@@ -5,4 +5,11 @@ function enterReasonForNoMRNAndContinue(commonContent, reason) {
   I.click(commonContent.continue);
 }
 
-module.exports = { enterReasonForNoMRNAndContinue };
+function enterReasonForNoMRNAndContinueAfterSignIn(commonContent, reason) {
+  const I = this;
+
+  I.fillField('#reasonForNoMRN', reason);
+  I.click(commonContent.saveAndContinue);
+}
+
+module.exports = { enterReasonForNoMRNAndContinue, enterReasonForNoMRNAndContinueAfterSignIn };

--- a/test/e2e/page-objects/cya/checkYourAppeal.js
+++ b/test/e2e/page-objects/cya/checkYourAppeal.js
@@ -99,6 +99,22 @@ function enterDetailsFromStartToDraftAppeals(commonContent, language, newUserEma
   I.enterAppellantNINOAndContinueAfterSignIn(commonContent, appellant.nino);
 }
 
+async function enterDetailsFromStartToDraft(commonContent, language, newUserEmail, benefitTypeCode = testDataEn.benefitType.code) {
+  const I = this;
+
+  I.enterBenefitTypeAndContinue(commonContent, benefitTypeCode);
+  I.chooseLanguagePreference(commonContent, 'no');
+  I.enterPostcodeAndContinue(commonContent, appellant.contactDetails.postCode);
+  I.continueFromIndependance(commonContent);
+  I.selectIfYouWantToCreateAccount(commonContent, '#createAccount-yes');
+  await I.signInVerifylanguage(newUserEmail, testDataEn.signIn.password, language);
+  I.createNewApplication(language);
+  I.enterBenefitTypeAfterSignIn(commonContent, benefitTypeCode);
+  I.chooseLanguagePreferenceAfterSignIn(commonContent, 'no');
+  I.enterPostcodeAndContinueAfterSignIn(commonContent, appellant.contactDetails.postCode);
+  I.continueFromIndependance(commonContent);
+}
+
 function enterDetailsForNewApplication(commonContent, language, userEmail, benefitTypeCode = testDataEn.benefitType.code) {
   const I = this;
 
@@ -276,10 +292,27 @@ function checkYourAppealToConfirmationPage(language, signer) {
   I.checkYourAppealToConfirmation(language, signer);
 }
 
+function continueIncompleteAppeal(language) {
+  const I = this;
+  I.seeCurrentUrlEquals(paths.checkYourAppeal);
+  if (language === 'en') {
+    I.see('Check your answers');
+    I.see('Your application is incomplete');
+    I.see('There are still some questions to answer.');
+    I.click('Continue your application');
+  } else {
+    I.see('Gwiriwch eich atebion');
+    I.see('Mae eich cais yn anghyflawn');
+    I.see('Mae yna gwestiynau nad ydych wedi’u hateb.');
+    I.click('Parhau á’ch cais');
+  }
+}
+
 module.exports = {
   enterDetailsFromStartToNINO,
   enterCaseDetailsFromStartToNINO,
   enterDetailsFromStartToDraftAppeals,
+  enterDetailsFromStartToDraft,
   enterDetailsForNewApplication,
   enterDetailsToArchiveACase,
   enterDetailsFromNoRepresentativeToUploadingEvidence,
@@ -289,5 +322,6 @@ module.exports = {
   confirmDetailsArePresent,
   enterDetailsFromAttendingTheHearingWithSupportToEnd,
   checkYourAppealToConfirmationPage,
-  enterDetailsFromNoRepresentativeToNoUploadingEvidence
+  enterDetailsFromNoRepresentativeToNoUploadingEvidence,
+  continueIncompleteAppeal
 };

--- a/test/e2e/page-objects/draft-appeals/draft-appeals-page.js
+++ b/test/e2e/page-objects/draft-appeals/draft-appeals-page.js
@@ -1,3 +1,5 @@
+const paths = require('paths');
+
 function verifyDraftAppealsAndEditACase(language) {
   const I = this;
 
@@ -44,4 +46,51 @@ function verifyDraftAppealsAndArchiveACase() {
   I.dontSee('Archive');
 }
 
-module.exports = { verifyDraftAppealsAndEditACase, verifyDraftAppealsAndArchiveACase };
+async function editDraftAppeal(language) {
+  const I = this;
+
+  I.seeElement(`.form-buttons-group [href='${paths.newAppeal}']`);
+  if (language === 'en') {
+    I.see('Your draft benefit appeals');
+    I.see('Edit');
+    I.see('Archive');
+    I.scrollTo('.govuk-table__cell:nth-child(1)');
+  } else {
+    I.see('Drafft o’ch apeliadau ynghylch budd-daliadau');
+    I.see('Golygu');
+    I.see('Cadw');
+    I.scrollTo('.govuk-table__cell:nth-child(1)');
+  }
+
+  const ccdCaseIDs = await I.grabTextFrom('.govuk-table__cell:nth-child(1)');
+  const ccdCaseID = Array.isArray(ccdCaseIDs) ? ccdCaseIDs[0] : ccdCaseIDs;
+
+  I.click(`[href='${paths.editDraft}?caseId=${ccdCaseID}']`);
+  I.wait(5);
+  const url = await I.grabCurrentUrl();
+  if (url.includes(paths.drafts)) {
+    I.click(`[href='${paths.editDraft}?caseId=${ccdCaseID}']`);
+    if (language === 'en') {
+      I.waitForText('Check your answers', 3);
+    } else {
+      I.waitForText('Gwiriwch eich atebion', 3);
+    }
+  }
+  return ccdCaseID;
+}
+
+
+function navigateToDrafts(language) {
+  const I = this;
+
+  I.amOnPage(`${paths.drafts}?lng=${language}`);
+  I.waitForElement(`.form-buttons-group [href='${paths.newAppeal}']`, 3);
+  if (language === 'en') {
+    I.see('Your draft benefit appeals');
+  } else {
+    I.see('Drafft o’ch apeliadau ynghylch budd-daliadau');
+  }
+  I.wait(3);
+}
+
+module.exports = { verifyDraftAppealsAndEditACase, verifyDraftAppealsAndArchiveACase, editDraftAppeal, navigateToDrafts };

--- a/test/e2e/page-objects/identity/appellantDetails.js
+++ b/test/e2e/page-objects/identity/appellantDetails.js
@@ -111,6 +111,24 @@ function enterAppellantContactDetailsAndContinue(commonContent, language) {
   I.click(commonContent.continue);
 }
 
+function enterAppellantContactDetailsAndContinueAfterSignIn(commonContent, language) {
+  const I = this;
+  const postcodeLookupContent = language === 'en' ? postcodeLookupContentEn : postcodeLookupContentCy;
+
+  if (postcodeLookupEnabled) {
+    I.fillField({ id: 'postcodeLookup' }, 'xxxxx');
+    I.click(postcodeLookupContent.findAddress);
+    I.see(postcodeLookupContent.fields.postcodeLookup.error.required);
+    I.fillField({ id: 'postcodeLookup' }, 'n29ed');
+    I.click(commonContent.continue);
+    I.see(postcodeLookupContent.fields.postcodeAddress.error.required);
+    IenterAddressDetails(postcodeLookupContent, I);
+  } else {
+    IenterAddressDetailsManual(I);
+  }
+  I.click(commonContent.saveAndContinue);
+}
+
 function enterAppellantContactDetailsWithMobileAndContinue(commonContent, language, mobileNumber = '07466748336') {
   const I = this;
   const postcodeLookupContent = language === 'en' ? postcodeLookupContentEn : postcodeLookupContentCy;
@@ -149,6 +167,7 @@ module.exports = {
   enterAppellantNINOAndContinue,
   enterAppellantNINOAndContinueAfterSignIn,
   enterAppellantContactDetailsAndContinue,
+  enterAppellantContactDetailsAndContinueAfterSignIn,
   enterAppellantContactDetailsWithMobileAndContinue,
   enterAppellantContactDetailsWithMobileAndContinueAfterSignIn,
   enterAppellantContactDetailsWithEmailAndContinue,

--- a/test/e2e/page-objects/sign-in/sign-in-with-valid-creds.js
+++ b/test/e2e/page-objects/sign-in/sign-in-with-valid-creds.js
@@ -1,9 +1,30 @@
+const paths = require('paths');
+
 function signIn(username, password, language) {
   const I = this;
   I.fillField({ id: 'username' }, username);
   I.fillField({ id: 'password' }, password);
   I.click({ name: 'save' });
   I.waitForElement(".form-buttons-group [href='/new-appeal']", 3);
+  if (language === 'en') {
+    I.see('Your draft benefit appeals');
+  } else {
+    I.see('Drafft o’ch apeliadau ynghylch budd-daliadau');
+  }
+}
+
+async function signInVerifylanguage(username, password, language) {
+  const I = this;
+  I.fillField({ id: 'username' }, username);
+  I.fillField({ id: 'password' }, password);
+  I.click({ name: 'save' });
+  I.waitForElement(".form-buttons-group [href='/new-appeal']", 10);
+  const altLang = await I.grabTextFrom('.language');
+  if ((altLang === 'English' && language === 'en') || (altLang === 'Cymraeg' && language === 'cy')) {
+    I.amOnPage(`${paths.drafts}?lng=${language}`);
+    I.wait(5);
+  }
+
   if (language === 'en') {
     I.see('Your draft benefit appeals');
   } else {
@@ -18,4 +39,4 @@ function navigateToSignInLink() {
 }
 
 
-module.exports = { signIn, navigateToSignInLink };
+module.exports = { signIn, signInVerifylanguage, navigateToSignInLink };

--- a/test/e2e/page-objects/tribunals-case-api/getCaseData.js
+++ b/test/e2e/page-objects/tribunals-case-api/getCaseData.js
@@ -3,36 +3,38 @@ const config = require('config');
 const tribunalsApiUrl = config.get('api.url');
 const authCookie = '__auth-token';
 
-async function getMYACaseData(commonContent, ccdCaseID) {
-  const I = this;
-  const res = await I.sendGetRequest(`${tribunalsApiUrl}/appeals?caseId=${ccdCaseID}`);
-
-  if (res.status === 200) {
-    if (res.data !== null && res.data.appeal !== null) {
-      return res.data.appeal;
+function checkTribunalAPIResponse(res) {
+  if (res && res.status === 200) {
+    if (res.data) {
+      return res.data;
     }
-    throw Error('Invalid API Response)');
+    throw Error('Invalid API Response no data returned');
   } else {
-    throw Error(`HTTP Error ${res.status} not correct`);
+    const status = res && res.status ? res.status : 'null';
+    throw Error(`HTTP Error ${status} is invalid`);
   }
 }
 
-async function getCaseData(commonContent, ccdCaseID) {
-  const I = this;
-  const myaCaseData = await I.getMYACaseData(commonContent, ccdCaseID);
+async function getMYACaseData(I, ccdCaseID) {
+  const res = await I.sendGetRequest(`${tribunalsApiUrl}/appeals?caseId=${ccdCaseID}`);
+  const caseData = checkTribunalAPIResponse(res);
+  if (caseData.appeal) {
+    return caseData.appeal;
+  }
+  throw Error('Invalid API Response appeal is missing from returned data');
+}
+
+async function getCaseData(I, ccdCaseID) {
+  const myaCaseData = await I.getMYACaseData(I, ccdCaseID);
+  if (!myaCaseData || !myaCaseData.appealNumber) {
+    throw Error('Invalid Appeal Number)');
+  }
   const tyaID = myaCaseData.appealNumber;
   const authTokenCookie = await I.grabCookie(authCookie);
   const headers = { Authorization: `Bearer ${authTokenCookie.value}` };
   const res = await I.sendGetRequest(`${tribunalsApiUrl}/api/citizen/${tyaID}`, headers);
 
-  if (res.status === 200) {
-    if (res.data !== null) {
-      return res.data;
-    }
-    throw Error('Invalid API Response)');
-  } else {
-    throw Error(`HTTP Error ${res.status} not correct`);
-  }
+  return checkTribunalAPIResponse(res);
 }
 
-module.exports = { getMYACaseData, getCaseData };
+module.exports = { checkTribunalAPIResponse, getMYACaseData, getCaseData };

--- a/test/e2e/page-objects/tribunals-case-api/getCaseData.js
+++ b/test/e2e/page-objects/tribunals-case-api/getCaseData.js
@@ -1,0 +1,38 @@
+const config = require('config');
+
+const tribunalsApiUrl = config.get('api.url');
+const authCookie = '__auth-token';
+
+async function getMYACaseData(commonContent, ccdCaseID) {
+  const I = this;
+  const res = await I.sendGetRequest(`${tribunalsApiUrl}/appeals?caseId=${ccdCaseID}`);
+
+  if (res.status === 200) {
+    if (res.data !== null && res.data.appeal !== null) {
+      return res.data.appeal;
+    }
+    throw Error('Invalid API Response)');
+  } else {
+    throw Error(`HTTP Error ${res.status} not correct`);
+  }
+}
+
+async function getCaseData(commonContent, ccdCaseID) {
+  const I = this;
+  const myaCaseData = await I.getMYACaseData(commonContent, ccdCaseID);
+  const tyaID = myaCaseData.appealNumber;
+  const authTokenCookie = await I.grabCookie(authCookie);
+  const headers = { Authorization: `Bearer ${authTokenCookie.value}` };
+  const res = await I.sendGetRequest(`${tribunalsApiUrl}/api/citizen/${tyaID}`, headers);
+
+  if (res.status === 200) {
+    if (res.data !== null) {
+      return res.data;
+    }
+    throw Error('Invalid API Response)');
+  } else {
+    throw Error(`HTTP Error ${res.status} not correct`);
+  }
+}
+
+module.exports = { getMYACaseData, getCaseData };

--- a/test/unit/getCaseData.test.js
+++ b/test/unit/getCaseData.test.js
@@ -1,0 +1,103 @@
+/* eslint-disable id-blacklist */
+const { expect } = require('test/util/chai');
+
+const GetCaseData = require('../e2e/page-objects/tribunals-case-api/getCaseData.js');
+
+describe('getCaseData E2E function', () => {
+  const ccdCaseID = '1641472310079136';
+  let apiResponse = {};
+  let myaCaseResponse = {};
+
+  const I = {
+    getMYACaseData: () => {
+      return myaCaseResponse;
+    },
+    sendGetRequest: () => {
+      return apiResponse;
+    },
+    grabCookie: () => {
+      return '00000000000000000000';
+    }
+  };
+
+  describe('checkTribunalAPIResponse', () => {
+    it('should return the response\'s data structure is correct', () => {
+      apiResponse = {
+        status: 200,
+        data: {
+          appeal: {}
+        }
+      };
+      expect(GetCaseData.checkTribunalAPIResponse(apiResponse)).to.equal(apiResponse.data);
+    });
+    it('should return a HTTP 404 error if the resource is not found', () => {
+      apiResponse = {
+        status: 404
+      };
+      expect(() => GetCaseData.checkTribunalAPIResponse(apiResponse)).to.throw(`HTTP Error ${apiResponse.status} is invalid`);
+    });
+    it('should return a HTTP 500 error if there is a internal server error', () => {
+      apiResponse = {
+        status: 500
+      };
+      expect(() => GetCaseData.checkTribunalAPIResponse(apiResponse)).to.throw(`HTTP Error ${apiResponse.status} is invalid`);
+    });
+    it('should return a null error when there is a null response', () => {
+      apiResponse = null;
+      expect(() => GetCaseData.checkTribunalAPIResponse(apiResponse)).to.throw('HTTP Error null is invalid');
+    });
+    it('should return a invalid api response error when there is no data in the response', () => {
+      apiResponse = {
+        status: 200
+      };
+      expect(() => GetCaseData.checkTribunalAPIResponse(apiResponse)).to.throw('Invalid API Response no data returned');
+    });
+  });
+
+  describe('getMYACaseData', () => {
+    it('should generate and return the correct response when the structure is correct', async() => {
+      apiResponse = {
+        status: 200,
+        data: {
+          appeal: {
+            appealNumber: 'bVLwEI7OQY'
+          }
+        }
+      };
+      const resMYACaseData = await GetCaseData.getMYACaseData(I, ccdCaseID);
+      expect(apiResponse.data.appeal).to.equal(resMYACaseData);
+    });
+
+    it('should return a invalid api response error when there is no appealNumber in the response', () => {
+      apiResponse = {
+        status: 200,
+        data: {}
+      };
+      expect(GetCaseData.getMYACaseData(I, ccdCaseID)).to.be.rejectedWith('Invalid API Response appeal is missing from returned data');
+    });
+  });
+  describe('getCaseData', () => {
+    it('should generate and return the correct response when the structure is correct', async() => {
+      myaCaseResponse = { appealNumber: 'bVLwEI7OQY' };
+      apiResponse = {
+        status: 200,
+        data: [
+          {
+            appeal_details: {
+              state: 'validAppeal'
+            }
+          }
+        ]
+      };
+      const resCaseData = await GetCaseData.getCaseData(I, ccdCaseID);
+      expect(apiResponse.data).to.equal(resCaseData);
+    });
+    it('should return a invalid appeal number error when the getMYACaseData response is empty', () => {
+      myaCaseResponse = null;
+      apiResponse = {
+        status: 200
+      };
+      expect(GetCaseData.getCaseData(I, ccdCaseID)).to.be.rejectedWith('Invalid Appeal Number)');
+    });
+  });
+});


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-9025


### Change description ###
Adding the tags so that the following are run with nightly tests:
- https://github.com/hmcts/sscs-submit-your-appeal/blob/master/test/e2e/journeys/noMRN.en.test.js
- https://github.com/hmcts/sscs-submit-your-appeal/blob/master/test/e2e/journeys/mrnLate.en.test.js

Adding new logic to allow calling the Tribual Case API and getting case data
Creating a new test (for both en and cy) to test the status of the case on CCD when a draft is submitted when signed in
Adding missing logic for navigating while signed in

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
