### PR TITLE
Add yarn start:dev command to remove need for docker compose (hopefully)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ an appeal summary page, allowing the user to edit their answers or sign and subm
 
 **Config**
 
+
 Redis is required to run the application. You can either install it or use a docker image (See docker section below for instructions).
-Install Redis: download, extract and build:
+
+### If Redis is already installed on your system
+You can simply start the application with `yarn start:dev`.
+
+### Install Redis: 
+download, extract and build:
 
     http://download.redis.io/redis-stable.tar.gz
     tar xvzf redis-stable.tar.gz

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "cross-env NODE_PATH=. NODE_OPTIONS=--openssl-legacy-provider node server.js",
+    "start:dev": "redis-server 2>&1 & ./bin/generate-ssl-options.sh && cross-env NODE_ENV=development NODE_PATH=. NODE_OPTIONS=--openssl-legacy-provider node server.js",
     "build": "NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider webpack --config webpack.config.js",
     "dev": "./bin/generate-ssl-options.sh && cross-env NODE_ENV=development NODE_PATH=. NODE_OPTIONS=--openssl-legacy-provider node server.js",
     "debug": "NODE_ENV=development cross-env NODE_PATH=. NODE_OPTIONS=--openssl-legacy-provider node --inspect server.js",


### PR DESCRIPTION
`yarn start:dev` should now allow the service to start locally without needing docker.