### PR TITLE
SSCSCI-1502: Fix for the answers to also have Welsh option available

### DIFF
--- a/steps/identity/appellant-contact-details/AppellantContactDetails.js
+++ b/steps/identity/appellant-contact-details/AppellantContactDetails.js
@@ -18,6 +18,7 @@ const config = require('config');
 const { decode } = require('utils/stringUtils');
 const PCL = require('components/postcodeLookup/controller');
 const { isIba } = require('utils/benefitTypeUtils');
+const i18next = require('i18next');
 
 const usePostcodeChecker = config.get('postcodeChecker.enabled');
 const url = config.postcodeLookup.url;
@@ -59,11 +60,11 @@ class AppellantContactDetails extends SaveToDraftStore {
   }
 
   get CYAPhoneNumber() {
-    return this.fields.phoneNumber.value || userAnswer.NOT_PROVIDED;
+    return this.fields.phoneNumber.value || userAnswer[i18next.language].NOT_PROVIDED;
   }
 
   get CYAEmailAddress() {
-    return this.fields.emailAddress.value || userAnswer.NOT_PROVIDED;
+    return this.fields.emailAddress.value || userAnswer[i18next.language].NOT_PROVIDED;
   }
 
   get form() {

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/OtherReasonForAppealing.js
@@ -8,6 +8,7 @@ const userAnswer = require('utils/answer');
 const { decode } = require('utils/stringUtils');
 const evidenceUploadEnabled = require('config').get('features.evidenceUpload.enabled');
 const { isIba } = require('utils/benefitTypeUtils');
+const i18next = require('i18next');
 
 class OtherReasonForAppealing extends SaveToDraftStore {
   static get path() {
@@ -30,7 +31,7 @@ class OtherReasonForAppealing extends SaveToDraftStore {
         question: this.content.cya.otherReasonForAppealing.question,
         section: sections.reasonsForAppealing,
         answer: decode(this.fields.otherReasonForAppealing.value) ||
-          userAnswer.NOT_REQUIRED
+          userAnswer[i18next.language].NOT_REQUIRED
       })
     ];
   }

--- a/steps/representative/representative-details/RepresentativeDetails.js
+++ b/steps/representative/representative-details/RepresentativeDetails.js
@@ -26,6 +26,7 @@ const userAnswer = require('utils/answer');
 const { decode } = require('utils/stringUtils');
 const PCL = require('components/postcodeLookup/controller');
 const config = require('config');
+const i18next = require('i18next');
 
 const url = config.postcodeLookup.url;
 const token = config.postcodeLookup.token;
@@ -51,20 +52,20 @@ class RepresentativeDetails extends SaveToDraftStore {
     const first = this.fields.name.first.value || '';
     const last = this.fields.name.last.value || '';
     return first === '' && last === '' ?
-      userAnswer.NOT_PROVIDED :
+      userAnswer[i18next.language].NOT_PROVIDED :
       `${repTitle} ${first} ${last}`.trim();
   }
 
   get CYAOrganisation() {
-    return this.fields.name.organisation.value || userAnswer.NOT_PROVIDED;
+    return this.fields.name.organisation.value || userAnswer[i18next.language].NOT_PROVIDED;
   }
 
   get CYAPhoneNumber() {
-    return this.fields.phoneNumber.value || userAnswer.NOT_PROVIDED;
+    return this.fields.phoneNumber.value || userAnswer[i18next.language].NOT_PROVIDED;
   }
 
   get CYAEmailAddress() {
-    return this.fields.emailAddress.value || userAnswer.NOT_PROVIDED;
+    return this.fields.emailAddress.value || userAnswer[i18next.language].NOT_PROVIDED;
   }
 
   get form() {

--- a/utils/answer.js
+++ b/utils/answer.js
@@ -12,9 +12,9 @@ const translationAnswers = {
     NOT_REQUIRED: 'Dim ei angen'
   }
 };
-
-const answer = translationAnswers.en;
-answer.en = translationAnswers.en;
-answer.cy = translationAnswers.cy;
+const answer = {
+  ...translationAnswers.en,
+  ...translationAnswers
+};
 
 module.exports = answer;

--- a/utils/answer.js
+++ b/utils/answer.js
@@ -1,8 +1,20 @@
-const answer = {
-  YES: 'yes',
-  NO: 'no',
-  NOT_PROVIDED: 'Not provided',
-  NOT_REQUIRED: 'Not required'
+const translationAnswers = {
+  en: {
+    YES: 'yes',
+    NO: 'no',
+    NOT_PROVIDED: 'Not provided',
+    NOT_REQUIRED: 'Not required'
+  },
+  cy: {
+    YES: 'Ydw',
+    NO: 'Nac ydw',
+    NOT_PROVIDED: 'Heb ei ddarparu',
+    NOT_REQUIRED: 'Dim ei angen'
+  }
 };
+
+const answer = translationAnswers.en;
+answer.en = translationAnswers.en;
+answer.cy = translationAnswers.cy;
 
 module.exports = answer;


### PR DESCRIPTION
### Jira link

See [SSCSCI-1507](https://tools.hmcts.net/jira/browse/SSCSCI-1507)

### Change description

- CYA page has no Welsh translation for 'not provided'
- Adding Welsh option to the answer util so the implementation wont change significantly 
- Will maintain a default to the english so existing implementations wont break

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
