### PR TITLE
Add hints for port of address and other reasons for appealing.

### DIFF
--- a/steps/identity/appellant-international-contact-details/content.en.json
+++ b/steps/identity/appellant-international-contact-details/content.en.json
@@ -38,6 +38,7 @@
     },
     "portOfEntry": {
       "title": "Port of entry",
+      "hint": "This is where you will expect to enter GB mainland by air/sea/train. You can change this at a later date if needed.",
       "error": {
         "required": "Select your port of entry into the UK",
         "invalid": "The port of entry is invalid"

--- a/steps/identity/appellant-international-contact-details/template.html
+++ b/steps/identity/appellant-international-contact-details/template.html
@@ -12,7 +12,7 @@
         {{ textbox(fields.townCity,                 content.fields.townCity.title,              hint="") }}
         {{ select(fields.country,                   content.fields.country.title,               options=getCountries) }}
         {{ textbox(fields.postCode,                 content.fields.postCode.title,            hint="") }}
-        {{ select(fields.portOfEntry,               content.fields.portOfEntry.title,           options=getPortOfEntryList) }}
+        {{ select(fields.portOfEntry,               content.fields.portOfEntry.title,           hint=content.fields.portOfEntry.hint,           options=getPortOfEntryList)}}
         {{ textbox(fields.phoneNumber,              content.fields.phoneNumber.title,           hint=content.fields.phoneNumber.hint) }}
         {{ textbox(fields.emailAddress,             content.fields.emailAddress.title,          hint=content.fields.emailAddress.hint) }}
     {% endcall %}

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/content.en.json
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/content.en.json
@@ -6,7 +6,8 @@
   "additonalInfo": "You don’t have to write anything, if you have nothing further to add.",
   "fields": {
     "otherReasonForAppealing": {
-      "label": "Other reasons for appealing"
+      "label": "Other reasons for appealing",
+      "hint": "(optional)"
     }
   },
   "cya": {

--- a/steps/reasons-for-appealing/other-reasons-for-appealing/template.html
+++ b/steps/reasons-for-appealing/other-reasons-for-appealing/template.html
@@ -9,7 +9,7 @@
         <p class="govuk-body">{{ content["subtitle" + suffix] }}</p>
         <p class="govuk-body">{{ content.additonalInfo }}</p>
 
-        {{ textarea(fields.otherReasonForAppealing, content.fields.otherReasonForAppealing.label, hideLabel = true) }}
+        {{ textarea(fields.otherReasonForAppealing, content.fields.otherReasonForAppealing.label, hideLabel = true, hint=content.fields.otherReasonForAppealing.hint) }}
     {% endcall %}
 {% endblock %}
 

--- a/views/components/fields.njk
+++ b/views/components/fields.njk
@@ -226,9 +226,7 @@
          for="{{ field.id }}">
     {{ label }}
     {%- if hint %}
-    <span class="hint-text">
-      {{ hint }}
-    </span>
+          <div id="{{ field.id }}-hint" class="govuk-hint">{{ hint }}</div>
     {%- endif %}
   </label>
 


### PR DESCRIPTION
### Jira link

See [SSCSCI-1450](https://tools.hmcts.net/jira/browse/SSCSCI-1450)

### Change description

Add hint text for the following pages in the SYA journey for IBA: 
- appellant-international-contact-details -> port of entry field
- other-reasons-for-appealing -> free text field

I've changed the select field defined views/components/fields.njk to use the correct hint div. Was previously using span, likely due to a section hint not being previously used.


https://design-system.service.gov.uk/components/select/


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
