### PR TITLE
Implement accessibility changes for SSCSCI-1610

### DIFF
--- a/steps/check-your-appeal/template.html
+++ b/steps/check-your-appeal/template.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block statement_of_truth_content %}
-    {{ header(content.header, size='m') }}
+    <h2 id="{{ content.header }}">{{ content.header }}</h2>
     <p class="govuk-body">{{ content.information }}</p>
     <p class="govuk-body">{{ content.permission }}</p>
     <p class="govuk-body">{{ content.agreeIbc | safe if isIba else content.agree | safe }}</p>

--- a/steps/hearing/options/template.html
+++ b/steps/hearing/options/template.html
@@ -7,7 +7,7 @@
     <p class="govuk-body">{{ content.subtitle }}</p>
     <p class="govuk-body">{{ content.tribunalExplained }}</p>
     <p class="govuk-body">{{ content.supportExplained }}</p>
-    <p class="govuk-heading-m">{{ content.fields.title }}</p>
+    <h2 class="govuk-heading-m">{{ content.fields.title }}</h2>
     <p class="govuk-hint">{{ content.instructions }}</p>
 
 

--- a/steps/hearing/the-hearing/template.html
+++ b/steps/hearing/the-hearing/template.html
@@ -6,14 +6,14 @@
 {% block fields %}
         <p class="govuk-body">{{ content.subtitle }}</p>
 
-        <p class="govuk-heading-m">{{ content.hearingFormatsList.title }}</p>
+        <h2 class="govuk-heading-m">{{ content.hearingFormatsList.title }}</h2>
         <p class="govuk-body">{{ content.hearingFormatsList.subtitle }}</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>{{ content.hearingFormatsList.bulletPoint1 }}</li>
             <li>{{ content.hearingFormatsList.bulletPoint2 }}</li>
         </ul>
 
-        <p class="govuk-heading-m">{{ content.hearingSupportList.title }}</p>
+        <h2 class="govuk-heading-m">{{ content.hearingSupportList.title }}</h2>
         <p class="govuk-body">{{ content.hearingSupportList.subtitle }}</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>{{ content.hearingSupportList.bulletPoint1 }}</li>

--- a/steps/identity/appellant-ibca-reference/content.en.json
+++ b/steps/identity/appellant-ibca-reference/content.en.json
@@ -4,7 +4,8 @@
   "subtitle": "You can find your IBCA Reference number on your Review Decision Notice.",
   "fields": {
     "ibcaReference": {
-      "title": "IBCA Reference number",
+      "title": "IBCA Reference number",  
+      "hint" : "This will have the following format - a12b34",
       "error": {
         "required": "An IBCA reference is required to update this case. Please refer to your Review Decision Notice.",
         "invalid": "The IBCA reference you entered is invalid. Please refer to your Review Decision Notice."

--- a/steps/identity/appellant-ibca-reference/template.html
+++ b/steps/identity/appellant-ibca-reference/template.html
@@ -6,6 +6,6 @@
 {% block fields %}
     {% call formSection() %}
             <p class="govuk-body">{{ content.subtitle }}</p>
-        {{ textbox(fields.ibcaReference, content.fields.ibcaReference.title, hint="") }}
+        {{ textbox(fields.ibcaReference, content.fields.ibcaReference.title, hint=content.fields.ibcaReference.hint) }}
     {% endcall %}
 {% endblock %}

--- a/views/components/check-your-answers.njk
+++ b/views/components/check-your-answers.njk
@@ -20,7 +20,7 @@
         {% endif %}
       </dd>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link" href="{{ url }}">
+        <a class="govuk-link" title="Change {{ question }}" href="{{ url }}">
           {{ commonContent.change }} <span class="govuk-visually-hidden">{{ question }}</span>
         </a>
       </dd>

--- a/views/components/fields.njk
+++ b/views/components/fields.njk
@@ -267,7 +267,7 @@
 <div class="govuk-form-group">
   {% if not hideQuestion %}
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-      <h1 class="govuk-fieldset__heading">{{ question }}</h1>
+      <h2 class="govuk-fieldset__heading">{{ question }}</h2>
     </legend>
     {% if hint %}
       <div id="{{ field.id }}-hint" class="govuk-hint">{{ hint }}</div>
@@ -287,7 +287,6 @@
           <input class="govuk-input govuk-date-input__input govuk-input--width-2 {{ errorClass(field.day, 'control') }} {{ errorClass(field, 'control') }}"
                  id="{{ field.day.id }}"
                  type="text" inputmode="numeric"
-                 pattern="[0-9]*"
                  min="1"
                  max="31"
                  name="{{ field.day.id }}"
@@ -312,7 +311,6 @@
           <input class="govuk-input govuk-date-input__input govuk-input--width-4 {{ errorClass(field.year, 'control') }} {{ errorClass(field, 'control') }}"
                  id="{{ field.year.id }}"
                  type="text" inputmode="numeric"
-                 pattern="[0-9]*"
                  min="1"
                  name="{{ field.year.id }}"
                  {% if field.year.value %}value="{{ field.year.value }}"{% endif %}>

--- a/views/layouts/check_your_answers.html
+++ b/views/layouts/check_your_answers.html
@@ -40,7 +40,7 @@
   {% for section in _sections %}
     {% if section.atLeast1Completed %}
       {% if section.title and _sections|length > 1 %}
-        {{ header(section.title, size='m') }}
+        <h2 id="{{section.title}}">{{ section.title }}</h2>
       {% endif %}
       {% for part in section.completedAnswers %}
         {% if not part.hide %}


### PR DESCRIPTION
### Jira link

Changes are as follows (more comprehensive descriptions are attached):

Check-your-appeal
- Updated the change link to include a title that describes the section of the form being changed
- Following titles repeated h1 tag - all have been updated to use h2 and correct id. 
  - Review Decision Notice
  - Claimant
  - Text message reminders
  - Representative
  - Reasons for appealing
  - The hearing
  - Hearing options
  - Sign and submit

The-hearing
- Both **Hearing formats** and **Hearing support** have been updated with the h2 tag.

Hearing-options
- **How would you prefer to take part in your hearing?** Has been updated with the h2 tag

IBCA reference
- Removed logic to allow invalid days and years to be served with gds compliant error messages instead https://design-system.service.gov.uk/components/error-message/
- Added the following as hint text **This will have the following format - a12b34**

See [SSCSCI-1610](https://tools.hmcts.net/jira/browse/SSCSCI-1610)

### Change description
