### PR TITLE
SSCSCI: @babel/preset-env bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.27.1",
-    "@babel/preset-env": "^7.27.2",
+    "@babel/preset-env": "^7.29.5",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.26.0",
     "@hmcts/cookie-manager": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,10 +463,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/compat-data@npm:7.29.0"
-  checksum: 10/7f21beedb930ed8fbf7eabafc60e6e6521c1d905646bf1317a61b2163339157fe797efeb85962bf55136e166b01fd1a6b526a15974b92a8b877d564dcb6c9580
+"@babel/compat-data@npm:^7.29.3":
+  version: 7.29.3
+  resolution: "@babel/compat-data@npm:7.29.3"
+  checksum: 10/3c29661756a7c1cbc5248a7bdc657c0cb49f350e3157040c20486759f1f50a08a0b385fd7d813df50b96cd6fad5896d30ba6abab7602641bd1410ed346c1812f
   languageName: node
   linkType: hard
 
@@ -1001,6 +1001,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@npm:^7.29.3":
+  version: 7.29.3
+  resolution: "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@npm:7.29.3"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.27.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10/fd13198afc9b72c6a4e4868f1592fc8010f390e7601148a71d2d6111664c0242d6d5ff27d8eb77ca4c35ef47f8416daf5dbc8d46a498ac706d69c6b3a0988cd7
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.27.1"
@@ -1365,9 +1377,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.0"
+"@babel/plugin-transform-modules-systemjs@npm:^7.29.4":
+  version: 7.29.4
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.4"
   dependencies:
     "@babel/helper-module-transforms": "npm:^7.28.6"
     "@babel/helper-plugin-utils": "npm:^7.28.6"
@@ -1375,7 +1387,7 @@ __metadata:
     "@babel/traverse": "npm:^7.29.0"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10/b3e64728eef02d829510778226da4c06be740fe52e0d45d4aa68b24083096d8ad7df67f2e9e67198b2e85f3237d42bd66f5771f85846f7a746105d05ca2e0cae
+  checksum: 10/79269e6ec8ec831bb63bf1c7cc1a980e28da785e92b36d42612f0139e4044499b99aa109fca849e1a156c092aabf6c24d145f4cabf2ac9ea84ef468852fe4c03
   languageName: node
   linkType: hard
 
@@ -1682,17 +1694,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.27.2":
-  version: 7.29.0
-  resolution: "@babel/preset-env@npm:7.29.0"
+"@babel/preset-env@npm:^7.29.5":
+  version: 7.29.5
+  resolution: "@babel/preset-env@npm:7.29.5"
   dependencies:
-    "@babel/compat-data": "npm:^7.29.0"
+    "@babel/compat-data": "npm:^7.29.3"
     "@babel/helper-compilation-targets": "npm:^7.28.6"
     "@babel/helper-plugin-utils": "npm:^7.28.6"
     "@babel/helper-validator-option": "npm:^7.27.1"
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "npm:^7.28.5"
     "@babel/plugin-bugfix-safari-class-field-initializer-scope": "npm:^7.27.1"
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "npm:^7.27.1"
+    "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "npm:^7.29.3"
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "npm:^7.27.1"
     "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "npm:^7.28.6"
     "@babel/plugin-proposal-private-property-in-object": "npm:7.21.0-placeholder-for-preset-env.2"
@@ -1724,7 +1737,7 @@ __metadata:
     "@babel/plugin-transform-member-expression-literals": "npm:^7.27.1"
     "@babel/plugin-transform-modules-amd": "npm:^7.27.1"
     "@babel/plugin-transform-modules-commonjs": "npm:^7.28.6"
-    "@babel/plugin-transform-modules-systemjs": "npm:^7.29.0"
+    "@babel/plugin-transform-modules-systemjs": "npm:^7.29.4"
     "@babel/plugin-transform-modules-umd": "npm:^7.27.1"
     "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.29.0"
     "@babel/plugin-transform-new-target": "npm:^7.27.1"
@@ -1758,7 +1771,7 @@ __metadata:
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 10/211b33ec8644636275f61aa273071d8cbc2a6bb28d82ad246e3831a6aa7d96c610a55b5140bcd21be7f71fb04c3aa4a10eb08665fb5505e153cfdd8dbc8c1c1c
+  checksum: 10/2e54630764b6650d81df5ce5a47fa260acd3695dc95a6b989b713bf6c0713fb320e3ae3f76f0c636bfda058ee5c582a3de7f5d58d691c68ca566129c7d3d0f0a
   languageName: node
   linkType: hard
 
@@ -11114,7 +11127,7 @@ __metadata:
   dependencies:
     "@axe-core/playwright": "npm:^4.10.1"
     "@babel/core": "npm:^7.27.1"
-    "@babel/preset-env": "npm:^7.27.2"
+    "@babel/preset-env": "npm:^7.29.5"
     "@babel/register": "npm:^7.27.1"
     "@eslint/eslintrc": "npm:^3.3.1"
     "@eslint/js": "npm:^9.26.0"


### PR DESCRIPTION
### Change description

Bumping [babel.dev/docs/en/next/babel-preset-env](https://babel.dev/docs/en/next/babel-preset-env) from `7.27.2` to `7.29.5` to resolve CVE-2026-44728. `@babel/plugin-transform-modules-systemjs` is a transitive dependency via `@babel/preset-env` hence the update.

### Testing done

Pipeline tests pass

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

| Package | Severity | Versions | Dependents | Issue |
| --- | --- | --- | --- | --- |
| loader-utils | critical | 0.2.17 | nunjucks-loader@virtual:35***12#npm:3.0.0 | [23] |
| glob | high | 10.4.5, 8.1.0 | mocha@npm:11.7.5, cacache@npm:16.1.3 | [16], [17] |
| hoek | high | 5.0.4, 6.1.3 | joi@npm:13.7.0, topo@npm:3.0.3 | [18] |
| ip | high | 2.0.1 | socks@npm:2.7.1 | [20] |
| json5 | high | 0.5.1 | loader-utils@npm:0.2.17 | [22] |
| minimatch | high | 3.1.2, 5.1.6, 9.0.5 | @eslint/eslintrc@npm:3.3.3, glob@npm:8.1.0, mocha@npm:11.7.5 | [25], [26], [27], [28], [29], [30], [31], [32], [33] |
| @npmcli/move-file | moderate | 2.0.1 | cacache@npm:16.1.3 | [1] |
| @otplib/plugin-crypto | moderate | 12.0.1 | @otplib/preset-default@npm:12.0.1 | [2] |
| @otplib/plugin-thirty-two | moderate | 12.0.1 | @otplib/preset-default@npm:12.0.1 | [3] |
| @otplib/preset-default | moderate | 12.0.1 | otplib@npm:12.0.1 | [4] |
| acorn-import-assertions | moderate | 1.9.0 | import-in-the-middle@npm:1.4.2 | [6] |
| ajv | moderate | 6.12.6, 8.12.0 | @eslint/eslintrc@npm:3.3.3, schema-utils@npm:4.2.0 | [7], [8] |
| are-we-there-yet | moderate | 3.0.1 | npmlog@npm:6.0.2 | [9] |
| brace-expansion | moderate | 2.0.1, 1.1.12 | minimatch@npm:9.0.5, minimatch@npm:3.1.2 | [10], [11], [12] |
| csurf | moderate | 1.11.0 | sya@workspace:. | [13] |
| gauge | moderate | 4.0.4 | npmlog@npm:6.0.2 | [15] |
| inflight | moderate | 1.0.6 | glob@npm:7.1.7 | [19] |
| joi | moderate | 13.7.0 | @hmcts/one-per-page@npm:5.4.0 | [21] |
| mem | moderate | 10.0.0 | @hmcts/div-idam-express-middleware@npm:7.0.1 | [24] |
| node-domexception | moderate | 1.0.0 | fetch-blob@npm:3.2.0 | [34] |
| npmlog | moderate | 6.0.2 | node-gyp@npm:9.3.1 | [35] |
| nunjucks | moderate | 3.2.3 | @hmcts/one-per-page@npm:5.4.0 | [36] |
| rimraf | moderate | 3.0.2 | node-gyp@npm:9.3.1 | [37] |
| stable | moderate | 0.1.8 | svgo@npm:2.8.2 | [38] |
| topo | moderate | 3.0.3 | joi@npm:13.7.0 | [39] |
| uuid | moderate | 10.0.0 | @hmcts/div-idam-express-middleware@npm:7.0.1 | [40] |
| @tootallnate/once | low | 2.0.0 | http-proxy-agent@npm:5.0.0 | [5] |
| diff | low | 7.0.0 | @hmcts/div-idam-express-middleware@npm:7.0.1 | [14] |


---

### 📝 Issue Notes

- **[1] @npmcli/move-file** — This functionality has been moved to @npmcli/fs
- **[2] @otplib/plugin-crypto** — Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
- **[3] @otplib/plugin-thirty-two** — Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
- **[4] @otplib/preset-default** — Please upgrade to v13 of otplib. Refer to otplib docs for migration paths
- **[5] @tootallnate/once** — @tootallnate/once vulnerable to Incorrect Control Flow Scoping (https://github.com/advisories/GHSA-vpq2-c234-7xj6)
- **[6] acorn-import-assertions** — package has been renamed to acorn-import-attributes
- **[7] ajv** — ajv has ReDoS when using `$data` option (https://github.com/advisories/GHSA-2g4f-4pwh-qvx6)
- **[8] ajv** — ajv has ReDoS when using `$data` option (https://github.com/advisories/GHSA-2g4f-4pwh-qvx6)
- **[9] are-we-there-yet** — This package is no longer supported.
- **[10] brace-expansion** — brace-expansion Regular Expression Denial of Service vulnerability (https://github.com/advisories/GHSA-v6h2-p8h4-qcjw)
- **[11] brace-expansion** — brace-expansion: Zero-step sequence causes process hang and memory exhaustion (https://github.com/advisories/GHSA-f886-m6hf-6m8v)
- **[12] brace-expansion** — brace-expansion: Zero-step sequence causes process hang and memory exhaustion (https://github.com/advisories/GHSA-f886-m6hf-6m8v)
- **[13] csurf** — This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions
- **[14] diff** — jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch (https://github.com/advisories/GHSA-73rr-hh4g-fpgx)
- **[15] gauge** — This package is no longer supported.
- **[16] glob** — glob CLI: Command injection via -c/--cmd executes matches with shell:true (https://github.com/advisories/GHSA-5j98-mcp5-4vw2)
- **[17] glob** — Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
- **[18] hoek** — hoek subject to prototype pollution via the clone function. (https://github.com/advisories/GHSA-c429-5p7v-vgjp)
- **[19] inflight** — This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
- **[20] ip** — ip SSRF improper categorization in isPublic (https://github.com/advisories/GHSA-2p57-rm9w-gvfp)
- **[21] joi** — This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
- **[22] json5** — Prototype Pollution in JSON5 via Parse Method (https://github.com/advisories/GHSA-9c47-m6qq-7p4h)
- **[23] loader-utils** — Prototype pollution in webpack loader-utils (https://github.com/advisories/GHSA-76p3-8jx3-jpfq)
- **[24] mem** — Renamed to memoize: https://www.npmjs.com/package/memoize
- **[25] minimatch** — minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern (https://github.com/advisories/GHSA-3ppc-4f35-3m26)
- **[26] minimatch** — minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern (https://github.com/advisories/GHSA-3ppc-4f35-3m26)
- **[27] minimatch** — minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern (https://github.com/advisories/GHSA-3ppc-4f35-3m26)
- **[28] minimatch** — minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments (https://github.com/advisories/GHSA-7r86-cg39-jmmj)
- **[29] minimatch** — minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments (https://github.com/advisories/GHSA-7r86-cg39-jmmj)
- **[30] minimatch** — minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments (https://github.com/advisories/GHSA-7r86-cg39-jmmj)
- **[31] minimatch** — minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions (https://github.com/advisories/GHSA-23c5-xmqv-rm74)
- **[32] minimatch** — minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions (https://github.com/advisories/GHSA-23c5-xmqv-rm74)
- **[33] minimatch** — minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions (https://github.com/advisories/GHSA-23c5-xmqv-rm74)
- **[34] node-domexception** — Use your platform's native DOMException instead
- **[35] npmlog** — This package is no longer supported.
- **[36] nunjucks** — Nunjucks autoescape bypass leads to cross site scripting (https://github.com/advisories/GHSA-x77j-w7wf-fjmw)
- **[37] rimraf** — Rimraf versions prior to v4 are no longer supported
- **[38] stable** — Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
- **[39] topo** — This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.
- **[40] uuid** — uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
