### PR TITLE
SSCSCI-534: Update image alt text to accurately describe content

### DIFF
--- a/steps/compliance/check-mrn/content.cy.json
+++ b/steps/compliance/check-mrn/content.cy.json
@@ -3,11 +3,11 @@
   "title": "Gwiriwch y dyddiad y gwnaethoch ei nodi",
   "subtitle": "Efallai bod eich apêl yn hwyr. Gwiriwch eich bod wedi nodi’r dyddiad sydd yng nghornel dde uchaf eich Hysbysiad Gorfodi i Ailystyried (MRN).",
   "question": "A wnaethoch nodi’r dyddiad sydd yng nghornel dde uchaf eich MRN?",
-  "imageAlt": "Copi o’ch MRN",
+  "imageAlt": "Enghraifft o lythyr Hysbysiad Gorfodi i Ailystyried yn dangos y dyddiad yng nghornel dde uchaf",
   "titleHeadIba": "Gwiriwch ddyddiad yr Hysbysiad o Benderfyniad Adolygiad",
   "subtitleIba": "Efallai y bydd eich apêl yn hwyr. Gwiriwch eich bod wedi nodi'r dyddiad sydd yng nghornel dde uchaf eich Hysbysiad o Benderfyniad Adolygiad.",
   "questionIba": "A wnaethoch chi nodi'r dyddiad sydd yng nghornel dde uchaf eich Hysbysiad o Benderfyniad Adolygiad?",
-  "imageAltIba": "Copi o’ch Hysbysiad o Benderfyniad Adolygiad",
+  "imageAltIba": "Enghraifft o lythyr Hysbysiad o Benderfyniad Adolygiad yn dangos y dyddiad yng nghornel dde uchaf",
   "fields": {
     "checkedMRN": {
       "yes": "Do, mi wnes i nodi’r dyddiad sydd yng nghornel dde uchaf fy MRN ",

--- a/steps/compliance/check-mrn/content.en.json
+++ b/steps/compliance/check-mrn/content.en.json
@@ -3,11 +3,11 @@
   "title": "Double check the date you entered",
   "subtitle": "Your appeal may be late. Just check you entered the date from the top right of your Mandatory Reconsideration Notice.",
   "question": "Did you enter the date from the top right of your MRN?",
-  "imageAlt": "A copy of your MRN",
+  "imageAlt": "Example Mandatory Reconsideration Notice letter showing the date in the top right corner",
   "titleHeadIba": "Double check Review Decision Notice date",
   "subtitleIba": "Your appeal may be late. Just check you entered the date from the top right of your Review Decision Notice.",
   "questionIba": "Did you enter the date from the top right of your Review Decision Notice?",
-  "imageAltIba": "A copy of your Review Decision Notice",
+  "imageAltIba": "Example Review Decision Notice letter showing the date in the top right corner",
   "fields": {
     "checkedMRN": {
       "yes": "Yes, I entered the date from the top right of my MRN",

--- a/steps/compliance/dwp-issuing-office-other/content.cy.json
+++ b/steps/compliance/dwp-issuing-office-other/content.cy.json
@@ -2,7 +2,7 @@
   "titleHead": "Rhif swyddfa DWP",
   "title": "Mae cyfeiriad DWP yng nghornel dde uchaf eich Hysbysiad Gorfodi i Ailystyried (MRN)",
   "noMRN": "Nid oes gennyf Hysbysiad Gorfodi i Ailystyried ",
-  "imageAlt": "Rhif swyddfa cyflwyno DWP",
+  "imageAlt": "Enghraifft o lythyr Hysbysiad Gorfodi i Ailystyried yn dangos enw swyddfa DWP ar linell gyntaf y cyfeiriad yng nghornel dde uchaf",
   "fields": {
     "dwpIssuingOffice": {
       "header": "Dewiswch y swyddfa a ddangosir yn llinell gyntaf cyfeiriad DWP",

--- a/steps/compliance/dwp-issuing-office-other/content.en.json
+++ b/steps/compliance/dwp-issuing-office-other/content.en.json
@@ -2,7 +2,7 @@
   "titleHead": "DWP office number",
   "title": "Find DWP’s address on the top right of your Mandatory Reconsideration Notice (MRN)",
   "noMRN": "I don’t have a Mandatory Reconsideration Notice",
-  "imageAlt": "A number of the DWP issuing office",
+  "imageAlt": "Example Mandatory Reconsideration Notice letter showing the DWP office name on the first line of the address in the top right corner",
   "fields": {
     "dwpIssuingOffice": {
       "header": "Select the office which is shown in the first line of DWP’s address",

--- a/steps/compliance/dwp-issuing-office/content.cy.json
+++ b/steps/compliance/dwp-issuing-office/content.cy.json
@@ -2,7 +2,8 @@
   "titleHead": "Rhif swyddfa DWP",
   "title": "Mae cyfeiriad DWP yng nghornel dde uchaf eich Hysbysiad Gorfodi i Ailystyried (MRN)",
   "noMRN": "Nid oes gennyf Hysbysiad Gorfodi i Ailystyried",
-  "imageAlt": "Rhif swyddfa cyflwyno DWP",
+  "imageAlt": "Enghraifft o lythyr Hysbysiad Gorfodi i Ailystyried yn dangos enw swyddfa DWP ar linell gyntaf y cyfeiriad yng nghornel dde uchaf",
+  "imageAltPip": "Enghraifft o lythyr Hysbysiad Gorfodi i Ailystyried yn dangos rhif y Taliad Annibyniaeth Personol ar linell gyntaf y cyfeiriad yng nghornel dde uchaf",
   "fields": {
     "pipNumber": {
       "header": "Dewiswch rif {{benefitName}} o gyfeiriad DWP",

--- a/steps/compliance/dwp-issuing-office/content.en.json
+++ b/steps/compliance/dwp-issuing-office/content.en.json
@@ -2,7 +2,8 @@
   "titleHead": "DWP office number",
   "title": "Find DWP’s address on the top right of your Mandatory Reconsideration Notice (MRN)",
   "noMRN": "I don’t have a Mandatory Reconsideration Notice",
-  "imageAlt": "A number of the DWP issuing office",
+  "imageAlt": "Example Mandatory Reconsideration Notice letter showing the DWP office name on the first line of the address in the top right corner",
+  "imageAltPip": "Example Mandatory Reconsideration Notice letter showing the Personal Independence Payment number on the first line of the address in the top right corner",
   "fields": {
     "pipNumber": {
       "header": "Select the {{benefitName}} number from DWP’s address",

--- a/steps/compliance/dwp-issuing-office/template.html
+++ b/steps/compliance/dwp-issuing-office/template.html
@@ -5,7 +5,7 @@
 
 {% block fields %}
     {% if (benefitCode == 'PIP') %}
-      <img class="mrn-image issuing-office" src="{{ asset_path }}images/dwp-office-number.png" alt="{{ content.imageAlt }}">
+      <img class="mrn-image issuing-office" src="{{ asset_path }}images/dwp-office-number.png" alt="{{ content.imageAltPip }}">
       <p class="govuk-body"><h2 class="govuk-heading-s">{{ content.fields.pipNumber.header }}</h2></p>
       {{ select(fields.pipNumber, content.fields.pipNumber.label, '', false, options) }}
     {% elif (benefitCode == 'ESA') or (benefitCode == 'DLA') or (benefitCode == 'attendanceAllowance') or (benefitCode == 'industrialInjuriesDisablement') or (benefitCode == 'JSA') or (benefitCode == 'socialFund') or (benefitCode == 'incomeSupport') or (benefitCode == 'UC') or (benefitCode == 'industrialDeathBenefit') or (benefitCode == 'pensionCredit') or (benefitCode == 'retirementPension') %}

--- a/steps/compliance/mrn-date/content.cy.json
+++ b/steps/compliance/mrn-date/content.cy.json
@@ -3,12 +3,12 @@
   "title": "Pa ddyddiad sydd ar eich Hysbysiad Gorfodi i Ailystyried (MRN)?",
   "dateLegend": "Nodwch y dyddiad sydd yng nghornel dde uchaf eich llythyr MRN",
   "dateHint": "Er enghraifft, 31 3 2017",
-  "imageAlt": "Copi o’ch MRN",
+  "imageAlt": "Enghraifft o lythyr Hysbysiad Gorfodi i Ailystyried yn dangos y dyddiad yng nghornel dde uchaf",
   "titleHeadIba": "Hysbysiad o Benderfyniad Adolygiad dyddiedig",
   "titleIba": "Beth yw dyddiad eich Hysbysiad o Benderfyniad Adolygiad?",
   "dateLegendIba": "Rhowch y dyddiad sydd yng nghornel dde uchaf eich Hysbysiad o Benderfyniad Adolygiad",
   "dateHintIba": "Er enghraifft, 26 1 2024",
-  "imageAltIba": "Copi o’ch Hysbysiad o Benderfyniad Adolygiad",
+  "imageAltIba": "Enghraifft o lythyr Hysbysiad o Benderfyniad Adolygiad yn dangos y dyddiad yng nghornel dde uchaf",
   "fields": {
     "date": {
       "day": "Diwrnod",

--- a/steps/compliance/mrn-date/content.en.json
+++ b/steps/compliance/mrn-date/content.en.json
@@ -3,12 +3,12 @@
   "title": "When is your Mandatory Reconsideration Notice (MRN) dated?",
   "dateLegend": "Enter the date from the top right of your MRN letter",
   "dateHint": "For example, 31 3 2017",
-  "imageAlt": "A copy of your MRN",
+  "imageAlt": "Example Mandatory Reconsideration Notice letter showing the date in the top right corner",
   "titleHeadIba": "Review Decision Notice dated",
   "titleIba": "When is your Review Decision Notice dated?",
   "dateLegendIba": "Enter the date from the top right of your Review Decision Notice",
   "dateHintIba": "For example, 26 1 2024",
-  "imageAltIba": "A copy of your Review Decision Notice",
+  "imageAltIba": "Example Review Decision Notice letter showing the date in the top right corner",
   "fields": {
     "date": {
       "day": "Day",


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/SSCSCI-534

### Change description
The helper images on MRN-related pages had generic alt text that did not describe the information actually conveyed in each image. Updated alt text for DWP office location, DWP office number (PIP), MRN date, UC MRN date, and Review Decision Notice date images across both English and Welsh.