### PR TITLE
SSCSCI-531 SSCSCI-532 Fix illogical heading order across pages

### DIFF
--- a/views/components/header.njk
+++ b/views/components/header.njk
@@ -24,8 +24,8 @@
     {% endif %}
     {{ heading }}
   {% if isPageHeader %}
-    </h2>
-  {% else %}
     </h1>
+  {% else %}
+    </h2>
   {% endif %}
 {% endmacro %}

--- a/views/layouts/add_another.html
+++ b/views/layouts/add_another.html
@@ -28,7 +28,7 @@
     {% block listItems %}
       {% call formSection() %}
         {% if not defaultContent.hideItemsListLabel %}
-          {{ header(defaultContent.itemsListLabel, size='m') }}
+          {{ header(defaultContent.itemsListLabel, size='m', isPageHeader=false) }}
         {% endif %}
 
         <dl class="govuk-summary-list">

--- a/views/layouts/check_your_answers.html
+++ b/views/layouts/check_your_answers.html
@@ -56,7 +56,7 @@
 
   {% if incomplete %}
     {% block continue_application %}
-      {{ header(pageContent.incompleteHeader | default(defaultContent.incompleteHeader), size='m') }}
+      {{ header(pageContent.incompleteHeader | default(defaultContent.incompleteHeader), size='m', isPageHeader=false) }}
       <p class="govuk-body">{{ pageContent.incompleteMessage | default(defaultContent.incompleteMessage) }}</p>
       <a href="{{ continueUrl }}" class="govuk-button">{{ pageContent.continue | default(defaultContent.continue) }}</a>
     {% endblock %}


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/SSCSCI-531
https://tools.hmcts.net/jira/browse/SSCSCI-532

### Change description
The header.njk macro had inverted closing tags - h1 opened with h2 close and vice versa. Fixed closing tags to match opening tags. Also added isPageHeader=false to sub-heading calls in check_your_answers.html and add_another.html layouts to ensure section headings render as h2 rather than h1.