### PR TITLE
Add new package rule to Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>hmcts/.github:renovate-config",
-    "github>hmcts/.github//renovate/automerge-all"
+    "github>hmcts/.github//renovate/automerge-all",
+    "github>hmcts/.github//renovate/cnp-jenkins-library"
   ],
 
   "packageRules": [


### PR DESCRIPTION
Platops now have a [global Renovate preset](https://github.com/hmcts/.github/blob/master/renovate/cnp-jenkins-library.json) you can [import into your existing Renovate config](https://github.com/hmcts/sds-toffee-frontend/blob/master/.github/renovate.json#L4) for this.
This will configure your Renovate to automatically track the library version updates.
Default behaviour is to auto-merge for Patch and Minor and only create PRs for Major version updates [but you can fine tune this as needed](https://github.com/hmcts/sds-toffee-frontend/blob/master/.github/renovate.json#L11).